### PR TITLE
Add helloapp streamlit interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Codex-Test
+# Codex Test
+
+This repository contains a small example Python project called **helloapp**. The
+project provides a command-line interface that prints a friendly greeting.
+
+## Usage
+
+After installing the package, run the command:
+
+```bash
+helloapp [name]
+```
+
+If `name` is provided, it will print `Hello, <name>!`. Otherwise it defaults to
+`Hello, World!`.
+
+## Web interface
+
+A small Streamlit UI is also available. Install the optional dependencies and
+run the app with:
+
+```bash
+pip install -e .[ui]
+streamlit run helloapp/app.py
+```
+
+## Development
+
+Install development dependencies and run the tests with:
+
+```bash
+pip install -e .[test]
+pytest
+```
+

--- a/helloapp/__init__.py
+++ b/helloapp/__init__.py
@@ -1,0 +1,5 @@
+"""Simple greeting application."""
+
+from .cli import greet, main
+
+__all__ = ["greet", "main"]

--- a/helloapp/app.py
+++ b/helloapp/app.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .cli import greet
+
+
+def main() -> None:
+    """Run the Streamlit web interface."""
+    import streamlit as st
+
+    st.title("Hello App")
+    name = st.text_input("Name", "World")
+    if st.button("Greet"):
+        st.write(greet(name))
+
+
+if __name__ == "__main__":
+    main()

--- a/helloapp/cli.py
+++ b/helloapp/cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import argparse
+
+
+def greet(name: str = "World") -> str:
+    """Return greeting message for the given name."""
+    return f"Hello, {name}!"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run command-line interface."""
+    parser = argparse.ArgumentParser(description="Greet the user")
+    parser.add_argument("name", nargs="?", default="World", help="Name to greet")
+    args = parser.parse_args(argv)
+    message = greet(args.name)
+    print(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "helloapp"
+version = "0.1.0"
+description = "Simple greeting application"
+authors = [{ name = "Codex" }]
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+helloapp = "helloapp.cli:main"
+
+[project.optional-dependencies]
+ui = ["streamlit>=1.0"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from helloapp.cli import greet
+import subprocess
+
+
+
+
+def test_greet():
+    assert greet("Codex") == "Hello, Codex!"
+
+
+def test_cli_output():
+    result = subprocess.run(
+        [sys.executable, "-m", "helloapp.cli", "Codex"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "Hello, Codex!"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,5 @@
+import helloapp.app as app
+
+
+def test_ui_main_callable():
+    assert callable(app.main)


### PR DESCRIPTION
## Summary
- create `helloapp/app.py` with a Streamlit UI
- document how to run the Streamlit UI in the README
- add optional dependency group `ui`
- include a simple test verifying the UI module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68601b66293883299522322c62c06bc2