### PR TITLE
Add risk simulation schemas, engine, and default config loader

### DIFF
--- a/src/risksim/__init__.py
+++ b/src/risksim/__init__.py
@@ -1,0 +1,6 @@
+"""Risk simulation package."""
+
+from .core.engine import Engine
+from .core.schemas import EngineConfig, load_defaults
+
+__all__ = ["Engine", "EngineConfig", "load_defaults"]

--- a/src/risksim/core/__init__.py
+++ b/src/risksim/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core components for risk simulation."""
+
+from .schemas import EngineConfig, load_defaults
+from .engine import Engine
+
+__all__ = ["Engine", "EngineConfig", "load_defaults"]

--- a/src/risksim/core/defaults.json
+++ b/src/risksim/core/defaults.json
@@ -1,0 +1,4 @@
+{
+  "peso_compra": 1.0,
+  "iterations": 1000
+}

--- a/src/risksim/core/engine.py
+++ b/src/risksim/core/engine.py
@@ -1,0 +1,33 @@
+"""Simple risk simulation engine using validated schemas."""
+from __future__ import annotations
+
+from typing import Union, Dict, Any
+
+from .schemas import EngineConfig, load_defaults
+
+
+class Engine:
+    """Risk simulation engine.
+
+    Parameters
+    ----------
+    config:
+        Configuration for the engine. A dictionary can be provided and will be
+        validated through :class:`EngineConfig`. If ``None`` a default
+        configuration is loaded via :func:`load_defaults`.
+    """
+
+    def __init__(self, config: Union[EngineConfig, Dict[str, Any], None] = None) -> None:
+        if config is None:
+            config = load_defaults()
+        elif isinstance(config, dict):
+            config = EngineConfig(**config)
+        self.config = config
+
+    def run(self) -> float:
+        """Run the simulation and return a dummy result.
+
+        The implementation here is purposely simple; it merely returns a value
+        based on the configuration to demonstrate usage of the validated schema.
+        """
+        return self.config.peso_compra * self.config.iterations

--- a/src/risksim/core/schemas.py
+++ b/src/risksim/core/schemas.py
@@ -1,0 +1,53 @@
+"""Schemas and configuration helpers for the risk simulator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+import json
+
+
+@dataclass
+class EngineConfig:
+    """Configuration for the risk simulation engine.
+
+    Attributes
+    ----------
+    peso_compra:
+        Positive purchase weight.
+    iterations:
+        Number of simulation iterations; must be greater than zero.
+    """
+
+    peso_compra: float
+    iterations: int = 1000
+
+    def __post_init__(self) -> None:
+        if self.peso_compra <= 0:
+            raise ValueError("peso_compra must be > 0")
+        if self.iterations <= 0:
+            raise ValueError("iterations must be > 0")
+
+
+def load_defaults(path: Optional[Union[str, Path]] = None) -> EngineConfig:
+    """Load default configuration for the simulator.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the JSON file containing defaults. If not supplied, a
+        ``defaults.json`` file located in the same directory as this module is
+        used.
+
+    Returns
+    -------
+    EngineConfig
+        Parsed configuration object with validated values.
+    """
+    if path is None:
+        path = Path(__file__).with_name("defaults.json")
+    else:
+        path = Path(path)
+
+    data = json.loads(path.read_text())
+    return EngineConfig(**data)


### PR DESCRIPTION
## Summary
- add dataclass-based `EngineConfig` and `load_defaults` in `schemas`
- implement `Engine` using validated schema instead of raw dicts
- include default configuration JSON for safer defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64984cbec8329ace5c048c991ada7