### PR TITLE
Add JSON scenario storage with CLI and UI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 RiskSim provides core calculations for livestock risk and profit analysis. The
 package exposes a small API for computing margins, breakeven prices and related
 metrics given production parameters. A simple command line interface is
-available as an example entry point.
+available as an example entry point. Scenarios can be persisted to disk using a
+lightweight JSON repository so that they may be reused or shared.
 
 ## Installation
 
@@ -13,11 +14,44 @@ pip install -e .
 
 ## Command line usage
 
+The CLI now exposes a small set of sub-commands:
+
 ```bash
-risksim PRECIO_COMPRA PRECIO_VENTA PESO_COMPRA PESO_SALIDA PRECIO_POR_TN CONVERSION MORTANDAD ADPV ESTADIA SANIDAD NUM_CABEZAS
+# run a one-off calculation
+risksim run PRECIO_COMPRA PRECIO_VENTA PESO_COMPRA PESO_SALIDA PRECIO_POR_TN CONVERSION MORTANDAD ADPV ESTADIA SANIDAD --num_cabezas 10
+
+# scenario CRUD operations
+risksim scenario save my-scenario PRECIO_COMPRA PRECIO_VENTA PESO_COMPRA PESO_SALIDA PRECIO_POR_TN CONVERSION MORTANDAD ADPV ESTADIA SANIDAD
+risksim scenario list
+risksim scenario show my-scenario
+risksim scenario delete my-scenario
 ```
 
-The command will print the margin neto for the provided parameters.
+`run` prints the margin neto for the provided parameters. Scenarios are stored
+in a JSON file (``scenarios.json`` by default) that can be backed up or shared
+between environments.
+
+## Streamlit UI
+
+For an interactive front-end, install the optional ``ui`` dependency and run
+
+```bash
+streamlit run -m risksim.ui
+```
+
+The sidebar exposes a modal for saving and loading scenarios.
+
+## Schema migrations
+
+Scenario files store a ``version`` field that allows the repository to migrate
+older files to the current schema. The ``risksim.storage.migrations`` module
+contains the upgrade logic.
+
+## Backup and restore
+
+Scenario files are ordinary JSON documents. To back up the repository simply
+copy ``scenarios.json`` somewhere safe. Use the ``backup`` and ``restore``
+helpers on ``ScenarioRepository`` if you prefer programmatic control.
 
 ## Development
 

--- a/risksim/cli.py
+++ b/risksim/cli.py
@@ -1,9 +1,11 @@
 import argparse
+from typing import Any
+
 from .core.calculations import InputParams, compute_profit
+from .storage import ScenarioRepository
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="RiskSim CLI")
+def add_param_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("precio_compra", type=float)
     parser.add_argument("precio_venta", type=float)
     parser.add_argument("peso_compra", type=float)
@@ -14,9 +16,40 @@ def main() -> None:
     parser.add_argument("adpv", type=float)
     parser.add_argument("estadia", type=float)
     parser.add_argument("sanidad", type=float)
-    parser.add_argument("num_cabezas", type=int, default=1)
-    args = parser.parse_args()
-    params = InputParams(
+    parser.add_argument("--num_cabezas", type=int, default=1)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="RiskSim CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    run = sub.add_parser("run", help="Run a scenario calculation")
+    add_param_arguments(run)
+
+    sc = sub.add_parser("scenario", help="Scenario storage operations")
+    sc_sub = sc.add_subparsers(dest="sc_command")
+
+    list_p = sc_sub.add_parser("list", help="List saved scenarios")
+    list_p.add_argument("--store", default="scenarios.json")
+
+    save_p = sc_sub.add_parser("save", help="Save a scenario")
+    save_p.add_argument("name")
+    add_param_arguments(save_p)
+    save_p.add_argument("--store", default="scenarios.json")
+
+    show_p = sc_sub.add_parser("show", help="Show a scenario")
+    show_p.add_argument("name")
+    show_p.add_argument("--store", default="scenarios.json")
+
+    del_p = sc_sub.add_parser("delete", help="Delete a scenario")
+    del_p.add_argument("name")
+    del_p.add_argument("--store", default="scenarios.json")
+
+    return parser
+
+
+def params_from_args(args: Any) -> InputParams:
+    return InputParams(
         precio_compra=args.precio_compra,
         precio_venta=args.precio_venta,
         num_cabezas=args.num_cabezas,
@@ -29,8 +62,42 @@ def main() -> None:
         estadia=args.estadia,
         sanidad=args.sanidad,
     )
-    result = compute_profit(params)
-    print(f"Margen neto: {result.margen_neto:.2f}")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "run":
+        params = params_from_args(args)
+        result = compute_profit(params)
+        print(f"Margen neto: {result.margen_neto:.2f}")
+        return
+
+    if args.command == "scenario":
+        repo = ScenarioRepository(getattr(args, "store", "scenarios.json"))
+        if args.sc_command == "list":
+            for scn in repo.list():
+                print(scn.name)
+            return
+        if args.sc_command == "save":
+            params = params_from_args(args)
+            repo.save(args.name, params)
+            print(f"Saved {args.name}")
+            return
+        if args.sc_command == "show":
+            scenario = repo.get(args.name)
+            if scenario:
+                print(scenario)
+            else:
+                print("Scenario not found")
+            return
+        if args.sc_command == "delete":
+            repo.delete(args.name)
+            print(f"Deleted {args.name}")
+            return
+
+    parser.print_help()
 
 
 if __name__ == "__main__":

--- a/risksim/storage/__init__.py
+++ b/risksim/storage/__init__.py
@@ -1,0 +1,3 @@
+from .repository import ScenarioRepository, Scenario
+
+__all__ = ["ScenarioRepository", "Scenario"]

--- a/risksim/storage/migrations.py
+++ b/risksim/storage/migrations.py
@@ -1,0 +1,18 @@
+"""Simple schema migration helpers for scenario storage."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = 1
+
+
+def migrate(data: dict) -> dict:
+    """Upgrade older schema versions to the current format."""
+    version = data.get("version", 0)
+    if version < 1:
+        # Legacy files may just be a list of scenarios without metadata
+        scenarios = data if isinstance(data, list) else data.get("scenarios", [])
+        data = {"version": 1, "scenarios": scenarios}
+        version = 1
+    # Future migrations would be chained here
+    data["version"] = SCHEMA_VERSION
+    return data

--- a/risksim/storage/repository.py
+++ b/risksim/storage/repository.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List, Optional
+
+from ..core.calculations import InputParams
+from .migrations import SCHEMA_VERSION, migrate
+
+
+@dataclass
+class Scenario:
+    """Represents a stored scenario."""
+
+    name: str
+    params: InputParams
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "params": asdict(self.params)}
+
+    @staticmethod
+    def from_dict(data: dict) -> "Scenario":
+        return Scenario(name=data["name"], params=InputParams(**data["params"]))
+
+
+class ScenarioRepository:
+    """Persist scenarios to a JSON file."""
+
+    def __init__(self, path: str | Path = "scenarios.json") -> None:
+        self.path = Path(path)
+        self.data = self._load()
+
+    def _load(self) -> dict:
+        if not self.path.exists():
+            data = {"version": SCHEMA_VERSION, "scenarios": []}
+            self._write(data)
+            return data
+        with self.path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if data.get("version", 0) < SCHEMA_VERSION:
+            data = migrate(data)
+            self._write(data)
+        return data
+
+    def _write(self, data: dict) -> None:
+        self.path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    # CRUD operations
+    def list(self) -> List[Scenario]:
+        return [Scenario.from_dict(s) for s in self.data.get("scenarios", [])]
+
+    def get(self, name: str) -> Optional[Scenario]:
+        for s in self.data.get("scenarios", []):
+            if s["name"] == name:
+                return Scenario.from_dict(s)
+        return None
+
+    def save(self, name: str, params: InputParams) -> Scenario:
+        scenario_dict = Scenario(name, params).to_dict()
+        scenarios = self.data.setdefault("scenarios", [])
+        for idx, existing in enumerate(scenarios):
+            if existing["name"] == name:
+                scenarios[idx] = scenario_dict
+                self._write(self.data)
+                return Scenario.from_dict(scenario_dict)
+        scenarios.append(scenario_dict)
+        self._write(self.data)
+        return Scenario.from_dict(scenario_dict)
+
+    def delete(self, name: str) -> None:
+        scenarios = self.data.get("scenarios", [])
+        self.data["scenarios"] = [s for s in scenarios if s["name"] != name]
+        self._write(self.data)
+
+    # Backup and restore helpers
+    def backup(self, backup_path: str | Path) -> Path:
+        backup_path = Path(backup_path)
+        shutil.copy(self.path, backup_path)
+        return backup_path
+
+    def restore(self, backup_path: str | Path) -> None:
+        backup_path = Path(backup_path)
+        shutil.copy(backup_path, self.path)
+        self.data = self._load()

--- a/risksim/ui.py
+++ b/risksim/ui.py
@@ -1,0 +1,58 @@
+"""Streamlit front-end with scenario save/load modal."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from .core.calculations import InputParams, compute_profit
+from .storage import ScenarioRepository
+
+
+def scenario_modal(repo: ScenarioRepository, params: InputParams) -> InputParams:
+    """Render a sidebar modal for saving and loading scenarios.
+
+    Returns the loaded InputParams if a scenario is loaded, otherwise the
+    original params.
+    """
+
+    with st.sidebar.expander("Scenarios", expanded=False):
+        save_name = st.text_input("Save as", key="save_name")
+        if st.button("Save scenario") and save_name:
+            repo.save(save_name, params)
+            st.success(f"Saved {save_name}")
+
+        scenarios = repo.list()
+        names = [s.name for s in scenarios]
+        load_name = st.selectbox("Load", options=names, key="load_name")
+        if st.button("Load scenario") and load_name:
+            loaded = repo.get(load_name)
+            if loaded:
+                st.info(f"Loaded {load_name}")
+                return loaded.params
+    return params
+
+
+def app() -> None:
+    repo = ScenarioRepository()
+    params = InputParams(
+        precio_compra=st.number_input("Precio compra", value=950.0),
+        precio_venta=st.number_input("Precio venta", value=835.0),
+        num_cabezas=st.number_input("Num. cabezas", value=100, step=1),
+        peso_compra=st.number_input("Peso compra", value=200.0),
+        peso_salida=st.number_input("Peso salida", value=460.0),
+        precio_por_tn=st.number_input("Precio por TN", value=64.0),
+        conversion=st.number_input("Conversion", value=8.0),
+        mortandad=st.number_input("Mortandad", value=1.0),
+        adpv=st.number_input("ADPV", value=1.2),
+        estadia=st.number_input("Estadia", value=30.0),
+        sanidad=st.number_input("Sanidad", value=1200.0),
+    )
+
+    params = scenario_modal(repo, params)
+
+    result = compute_profit(params)
+    st.write(f"Margen neto: {result.margen_neto:.2f}")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/risksim/storage
+++ b/src/risksim/storage
@@ -1,0 +1,1 @@
+../../risksim/storage

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from risksim.core.calculations import InputParams
+from risksim.storage import ScenarioRepository
+
+
+def sample_params() -> InputParams:
+    return InputParams(
+        precio_compra=950,
+        precio_venta=835,
+        num_cabezas=100,
+        peso_compra=200,
+        peso_salida=460,
+        precio_por_tn=64,
+        conversion=8,
+        mortandad=1,
+        adpv=1.2,
+        estadia=30,
+        sanidad=1200,
+    )
+
+
+def test_repository_crud(tmp_path: Path) -> None:
+    repo = ScenarioRepository(tmp_path / "scenarios.json")
+    params = sample_params()
+    repo.save("baseline", params)
+    assert repo.get("baseline").params == params
+
+    # update
+    params2 = InputParams(**{**params.__dict__, "precio_compra": 900})
+    repo.save("baseline", params2)
+    assert repo.get("baseline").params == params2
+
+    repo.delete("baseline")
+    assert repo.get("baseline") is None
+
+
+def test_backup_and_restore(tmp_path: Path) -> None:
+    repo = ScenarioRepository(tmp_path / "scenarios.json")
+    repo.save("a", sample_params())
+    backup = tmp_path / "backup.json"
+    repo.backup(backup)
+
+    # remove and restore
+    repo.delete("a")
+    repo.restore(backup)
+    assert repo.get("a") is not None


### PR DESCRIPTION
## Summary
- add JSON-based `ScenarioRepository` for persisting scenarios
- extend CLI with scenario CRUD subcommands
- add Streamlit UI modal for saving/loading scenarios and document migration/backup procedures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b6a26edc832995533650b37c4d66