### PR TITLE
Introduce vNext isolated workspace with Twin core, capability façade, thin UI adapters, and Slice-1 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,44 @@
-# RiskSim
+# Twin vNext Product Line (Official)
 
-RiskSim provides core calculations for livestock risk and profit analysis. The
-package exposes a small API for computing margins, breakeven prices and related
-metrics given production parameters. A simple command line interface is
-available as an example entry point. Scenarios can be persisted to disk using a
-lightweight JSON repository so that they may be reused or shared.
+This repository is now the **official Twin-centered vNext product line**.
 
-## Installation
+The product center is the Twin core, with two interfaces over the same operational truth:
 
-```bash
-pip install -e .
-```
+- **Human UI** (cockpit paths)
+- **Agent-facing API** (capability façade)
 
-## Command line usage
+## Product invariants
 
-The CLI now exposes a small set of sub-commands:
+These are non-negotiable in this repo:
 
-```bash
-# run a one-off calculation
-risksim run PRECIO_COMPRA PRECIO_VENTA PESO_COMPRA PESO_SALIDA PRECIO_POR_TN CONVERSION MORTANDAD ADPV ESTADIA SANIDAD --num_cabezas 10
+- One canonical workflow only: `start → capture → review/correct → save local → sync → retrieve → ask/reason → decide`.
+- Retrieval before reasoning is required.
+- UI remains thin; business logic stays in controller/service layers.
+- Twin core remains source of truth.
 
-# scenario CRUD operations
-risksim scenario save my-scenario PRECIO_COMPRA PRECIO_VENTA PESO_COMPRA PESO_SALIDA PRECIO_POR_TN CONVERSION MORTANDAD ADPV ESTADIA SANIDAD
-risksim scenario list
-risksim scenario show my-scenario
-risksim scenario delete my-scenario
-```
+## Where the active vNext product lives
 
-`run` prints the margin neto for the provided parameters. Scenarios are stored
-in a JSON file (``scenarios.json`` by default) that can be backed up or shared
-between environments.
+Primary implementation and product docs are under:
 
-## Streamlit UI
+- `next-version/`
+  - `vnext_twin_core/`
+  - `vnext_api/`
+  - `vnext_ui/`
+  - `tests/`
+  - architecture/adoption/merge docs
 
-For an interactive front-end, install the optional ``ui`` dependency and run
+Start with `next-version/README.md` for run and validation commands.
 
-```bash
-streamlit run -m risksim.ui
-```
+## Repository positioning
 
-The sidebar exposes a modal for saving and loading scenarios.
+Legacy/auxiliary code (e.g. the `risksim` package and related tests) remains in-repo for now, but it is **not** the forward product line.
+It is intentionally left untouched in this promotion step to keep diffs small and reversible.
 
-## Schema migrations
+## Manual GitHub rename step (outside Codex)
 
-Scenario files store a ``version`` field that allows the repository to migrate
-older files to the current schema. The ``risksim.storage.migrations`` module
-contains the upgrade logic.
+Codex cannot rename the GitHub repository itself. If desired, perform these manually:
 
-## Backup and restore
-
-Scenario files are ordinary JSON documents. To back up the repository simply
-copy ``scenarios.json`` somewhere safe. Use the ``backup`` and ``restore``
-helpers on ``ScenarioRepository`` if you prefer programmatic control.
-
-## Development
-
-Install development dependencies and run the tests with:
-
-```bash
-pip install -e .[test]
-pytest
-```
+1. GitHub repository rename
+2. Repository description/topics update
+3. Default branch/release policy alignment
+4. CI/workflow naming alignment

--- a/next-version/ADOPTION_SLICE_A.md
+++ b/next-version/ADOPTION_SLICE_A.md
@@ -1,0 +1,53 @@
+# ADOPTION_SLICE_A
+
+## Objective
+Define the smallest first adoption slice into real app direction while preserving hardened Slice-1 behavior.
+
+## Exact scope
+- Introduce one canonical cockpit path in baseline-aligned UI container.
+- Wire only the following actions through adapter boundary:
+  1. start visit
+  2. capture
+  3. review/correct
+  4. save local
+  5. sync status
+  6. retrieve
+  7. ask/reason
+  8. decide
+- Render result summary in same view.
+
+## Exact screens/components involved (minimal)
+- existing app shell/status area
+- one field-visit/cockpit view container
+- one assistant/retrieve+ask panel area
+- one decision/result summary panel
+
+No extra routes beyond these surfaces for Slice A.
+
+## Exact state surfaces involved
+- `visitId`
+- `sliceState`
+- `capturedObservation`
+- `correctedObservation`
+- `localSaveStatus`
+- `syncStatus`
+- `retrievalSummary`
+- `retrievalEventId`
+- `recommendation`
+- `decision`
+- `lastError`
+
+## Done criteria
+1. User can complete canonical flow end-to-end from one visible cockpit path.
+2. Sync status explicitly visible (`queued`/`succeeded` states) in shell/panel.
+3. Ask before retrieval is blocked and/or returns clear contract error.
+4. No duplicate workflow path exposed in UI.
+5. Existing Slice-1 behavioral tests still pass in isolated kernel.
+6. Adapter contract snapshot for Slice A is documented and stable.
+
+## Explicitly excluded from Slice A
+- real backend/model integration changes
+- additional screens/routes
+- styling redesign beyond clarity
+- non-slice features (analytics, reports, wearable flows)
+- Slice 2 capabilities

--- a/next-version/BASELINE_ADAPTER_PLAN.md
+++ b/next-version/BASELINE_ADAPTER_PLAN.md
@@ -1,0 +1,45 @@
+# BASELINE_ADAPTER_PLAN
+
+## Goal
+Define how the current `react_api` + `controller` boundary evolves toward baseline integration while preserving contracts and canonical flow.
+
+## Current boundary (in isolated vNext)
+- React UI -> `/api/action` + `/api/state` (`react_api.py`) -> `CockpitController` -> `TwinCapabilities` -> `TwinService`.
+
+## Evolution path toward baseline
+
+## Phase A: local client adapter (no backend coupling)
+- Replace HTTP loopback calls with an in-app adapter module in baseline UI layer.
+- Adapter exposes same action names and returns same state surface shape.
+- Controller semantics remain unchanged.
+
+## Phase B: split adapter responsibilities
+- **UI adapter**: presentation-facing state and error normalization.
+- **Domain adapter**: canonical action orchestration and contract mapping.
+- Keep Twin/service contracts as source of truth.
+
+## Phase C: selective backend-facing wiring (later)
+- For sync/retrieval calls, adapter may call baseline backend APIs.
+- Must preserve contract outputs used by UI (same state fields, same error semantics).
+- Retrieval-before-reasoning remains enforced before `ask` dispatch.
+
+## What remains local vs evolves
+### Remains local/contractual
+- canonical action ordering
+- validation expectations and state progression
+- status/error surface vocabulary
+
+### Becomes client-side adapter logic
+- mapping baseline UI events to canonical action calls
+- shaping backend responses into contract-consistent cockpit state
+
+### Becomes backend-facing later
+- sync transport implementation details
+- retrieval and reasoning provider calls
+- persistence/storage internals (while keeping contract outputs stable)
+
+## Non-negotiables during evolution
+1. Do not move business rules into React components.
+2. Do not bypass retrieval-before-reasoning.
+3. Do not introduce alternate action routes.
+4. Do not leak backend-specific payloads directly into UI state surface.

--- a/next-version/BASELINE_MERGE_CHECKLIST.md
+++ b/next-version/BASELINE_MERGE_CHECKLIST.md
@@ -1,0 +1,27 @@
+# BASELINE_MERGE_CHECKLIST
+
+## Pre-merge checklist
+- [ ] One canonical cockpit route defined (no parallel route exposed).
+- [ ] Adapter contract mirrors Slice-A action/state surface exactly.
+- [ ] Retrieval-before-reasoning enforced in adapter/service path.
+- [ ] Sync status visibility surface explicitly mapped (`queued/succeeded`).
+- [ ] Error surface (`lastError`) mapped to UI banner/section clearly.
+- [ ] No direct business-rule logic added to React components.
+- [ ] No backend/model coupling introduced beyond agreed wrappers.
+- [ ] Rollback units identified and tested locally (route, view, adapter).
+
+## Post-merge checklist
+- [ ] Canonical workflow reachable end-to-end in integrated route.
+- [ ] Ask before retrieval fails cleanly and visibly.
+- [ ] Sync status changes are visible and consistent with adapter state.
+- [ ] No duplicate orchestration flow visible in UI.
+- [ ] Existing relevant tests still pass.
+- [ ] New Slice-A integration tests pass.
+- [ ] No unrelated baseline modules modified.
+
+## Expected validation set
+- route smoke test for cockpit entry
+- canonical flow integration test
+- retrieval-before-reasoning negative test
+- sync status visibility test
+- error-surface test

--- a/next-version/BASELINE_SPIKE_BLOCKED_REPORT.md
+++ b/next-version/BASELINE_SPIKE_BLOCKED_REPORT.md
@@ -1,0 +1,47 @@
+# BASELINE_SPIKE_BLOCKED_REPORT
+
+## What must be preserved exactly (from safe-repo milestone)
+- One canonical workflow only: start visit → capture → review/correct → save local → sync → retrieve → ask/reason → decide → result summary.
+- Twin-core-first behavior and thin UI boundary (no business logic in React components).
+- Retrieval-before-reasoning as non-negotiable contract.
+- Explicit sync/status/error surfaces.
+- Minimal, reversible diffs with clear rollback points.
+
+## Real baseline repo access attempt
+Command attempted:
+
+```bash
+cd /workspace && git clone https://github.com/aciuffolini/Multimodal-Agentic-Farm-Visit.git baseline-spike
+```
+
+Result:
+- `fatal: unable to access 'https://github.com/aciuffolini/Multimodal-Agentic-Farm-Visit.git/': CONNECT tunnel failed, response 403`
+
+## Why the requested spike cannot be completed in this environment
+The tiny real integration spike requires a writable local checkout of the real baseline repo.
+Current environment blocks outbound git/http access to GitHub (403 tunnel failure), so the baseline code cannot be cloned, branched, edited, or validated.
+
+## Minimum touch points I would apply once baseline checkout is available
+1. `apps/web/src/App.tsx` (or route registry): add one route/entry to cockpit slice.
+2. `apps/web/src/views/CockpitSliceA.*`: thin container view.
+3. `apps/web/src/lib/cockpitAdapter.*`: thin adapter wiring to existing boundaries.
+4. Optional minimal shared type file in `packages/shared/*` if needed for stable state contract.
+
+Untouched initially:
+- backend runtime logic
+- model/retrieval provider internals
+- non-canonical routes
+- Capacitor internals (except trivial bootstrapping if strictly required)
+
+## Rollback triggers that would be watched during the real spike
+- ask/reason works before retrieval context
+- duplicate visible workflow path appears
+- UI components begin carrying business/validation logic
+- spike requires unexpected backend/model refactors
+
+## Smallest corrective adjustment needed
+Provide one of the following so the requested real spike can proceed:
+1. A local checkout of `Multimodal-Agentic-Farm-Visit` mounted in workspace, or
+2. Temporary outbound git/http access to clone the target repo.
+
+With either available, I can execute the tiny real spike exactly as requested and keep it reversible.

--- a/next-version/BASELINE_TO_VNEXT_MAPPING.md
+++ b/next-version/BASELINE_TO_VNEXT_MAPPING.md
@@ -1,0 +1,53 @@
+# BASELINE_TO_VNEXT_MAPPING
+
+## Mapping objective
+Translate baseline components into a clear vNext disposition:
+- Reuse as-is
+- Simplify
+- Deprecate
+- Redefine interface first
+
+## Baseline → vNext mapping matrix
+
+| Baseline component area | Current role | vNext disposition | Rationale |
+|---|---|---|---|
+| `apps/web/src` app shell + capture components | Human-facing capture/review flows | **Reuse + simplify** | Keep proven UX primitives, remove parallel flows and reduce controls to canonical verbs |
+| Local DB/persistence (`db`, local entities) | Local-first operational storage | **Reuse as-is (with schema hardening)** | This is core to Twin truth and offline continuity |
+| Outbox + queue dual implementations | Competing sync mechanisms | **Simplify to one canonical engine** | Parallel sync paths create state ambiguity and failure complexity |
+| Multiple API client paths (`api` variants) | Competing transport/stream abstractions | **Simplify to one client boundary** | Reduces drift and inconsistent error handling |
+| `server/rag_service` FastAPI endpoints | Sync/media/retrieval backend primitives | **Reuse + redefine contract façade** | Keep internals, expose capability-oriented Twin API |
+| Retrieval/embedding/media handling | Grounding context assembly | **Reuse + tighten provenance contract** | Retrieval is mandatory grounding stage before reasoning |
+| Chat/reasoning integration | Human ask/recommendation UX | **Simplify + gate by retrieval** | Prevent ungrounded outputs from being operational truth |
+| Capacitor/Android bridge | Mobile runtime bridge | **Reuse as-is initially** | Avoid platform churn in first coherent slice |
+| Build/dev/deploy scripts | Operational startup and release paths | **Simplify and normalize** | Current script sprawl increases onboarding and operational risk |
+| README/status docs | Product and architecture claims | **Redefine first** | Must remove doc-code drift before implementation scaling |
+
+## Interfaces to redefine first (priority order)
+1. **Twin event contract** (state + transitions)
+2. **Sync contract** (single queue semantics, idempotency, failure states)
+3. **Retrieval contract** (query, scope, provenance snapshot)
+4. **Reasoning contract** (`ask_twin` retrieval-gated)
+5. **UI status contract** (local/sync/retrieval/recommendation state vocabulary)
+
+## Reuse as-is (first pass)
+- Core local-first persistence posture.
+- Existing backend primitives in `server/rag_service`.
+- Existing capture and media collection foundations.
+- Existing Android bridge foundation.
+
+## Simplify immediately
+- Competing sync pathways.
+- Competing API client layers.
+- Duplicate user paths for similar actions.
+- Excess startup/run modes and ambiguous docs.
+
+## Deprecate (not delete immediately)
+- Legacy or duplicate sync path once canonical engine selected.
+- Non-canonical API helper path once unified client adopted.
+- Any UI flow that bypasses canonical capture→review→correct→sync loop.
+
+## What not to touch yet
+- New providers/models.
+- New wearable integrations.
+- Full backend or frontend rewrites.
+- Additional orchestration layers beyond capability API.

--- a/next-version/BASELINE_UI_ADOPTION_MAP.md
+++ b/next-version/BASELINE_UI_ADOPTION_MAP.md
@@ -1,0 +1,53 @@
+# BASELINE_UI_ADOPTION_MAP
+
+## Pre-write summary: what React cockpit proved vs unproven
+### Proven
+- Canonical Slice-1 flow can be executed through one thin React path.
+- UI can stay thin by delegating behavior to controller/capability boundary.
+- Required state/status surfaces are sufficient for operational clarity.
+- Retrieval-before-reasoning remains enforceable through service path.
+
+### Still unproven
+- Production React/Vite integration details in the baseline app shell.
+- Capacitor runtime behavior and mobile lifecycle interactions.
+- Real baseline component reuse efficiency without introducing parallel flow.
+- UX fit against existing baseline navigation and current module boundaries.
+
+## Mapping from thin cockpit to baseline UI structure
+
+| Thin cockpit surface | Baseline destination (conceptual) | Reuse opportunity |
+|---|---|---|
+| Status strip (visit id/state/save/sync/retrieval/recommendation) | existing app shell header/status region | reuse baseline shell layout + status components where available |
+| Start Visit action | field-visit entry screen/action area | reuse existing route/screen container |
+| Capture observation input | current field capture form section | reuse existing capture inputs/hooks; align labels to canonical flow |
+| Review/correct input | existing review/confirm modal or review panel | reuse modal/panel scaffolding; keep logic in adapter/controller |
+| Save Local + Sync controls | existing sync/outbox status area | reuse existing status widgets but wire to canonical contract surfaces |
+| Retrieve/Ask actions | existing chat/assistant drawer area | reuse drawer container; constrain to retrieval-first sequence |
+| Decide + Result summary | result/confirmation panel near chat/review | reuse card/summary components, keep minimal fields only |
+
+## Where each cockpit surface should live in baseline React/Vite/Capacitor app
+1. **App shell level**
+   - persistent status strip and error banner.
+2. **Field Visit route/view**
+   - start/capture/review/save/sync interactions.
+3. **Assistant/Ask panel**
+   - retrieve then ask.
+4. **Decision/summary area**
+   - finalize decision and show compact run summary.
+
+Capacitor-specific behavior should remain in device integration layer, not in cockpit business flow.
+
+## Baseline UI pieces likely reusable first
+- Existing React route/shell scaffold.
+- Existing capture form components and input hooks.
+- Existing sync status/outbox visual components.
+- Existing assistant panel container and rendering shell.
+
+## Baseline UI pieces to keep untouched for now
+- Non-canonical experimental flows.
+- Advanced analytics/reporting views.
+- Non-slice wearable/integration-specific UI areas.
+- Global design-system restyling work.
+
+## Adoption guardrail
+Never expose a second competing flow path in UI during adoption; map all visible actions to the canonical slice sequence.

--- a/next-version/CANONICAL_WORKFLOW.md
+++ b/next-version/CANONICAL_WORKFLOW.md
@@ -1,0 +1,51 @@
+# CANONICAL_WORKFLOW
+
+## Primary product loop
+Reality → Capture → Memory → Retrieval → Reasoning → Recommendation/Action → Feedback → Updated Twin
+
+## One primary workflow
+
+1. **Capture**
+   - User captures structured observations + media + context.
+2. **Review**
+   - User sees extracted fields, metadata, and capture completeness.
+3. **Correct**
+   - User edits inaccuracies before commit.
+4. **Save locally**
+   - Twin writes canonical local events/assets immediately.
+5. **Sync**
+   - Sync engine publishes queued events/media to backend when online.
+6. **Retrieve context**
+   - Retrieval assembles relevant Twin history and media context.
+7. **Ask / reason**
+   - Reasoning layer produces grounded interpretation and recommendations.
+8. **Decide**
+   - Human accepts/adjusts/rejects proposed action.
+9. **Write back**
+   - Decision + rationale + outcome are persisted as Twin events.
+
+## Offline behavior
+- Capture/review/correct/save must be fully local.
+- Retrieval uses local index first.
+- Reasoning may degrade to local model/rules if frontier unavailable.
+- All generated recommendations are marked with confidence/source mode.
+
+## Online behavior
+- Outbox sync runs continuously with idempotent semantics.
+- Retrieval may enrich from backend/global corpus.
+- Frontier reasoning can be invoked after retrieval snapshot is frozen.
+
+## Sync failure behavior
+- Failed sync attempts create explicit sync events.
+- User sees actionable failure states (retry now, retry later, inspect error).
+- No data loss: local Twin remains source of truth until confirmed sync.
+
+## Human correction loop
+- Corrections can happen before or after sync.
+- Every correction writes a correction event linked to original event.
+- Retrieval should prefer most recent validated state.
+
+## Agent-triggered workflow loop
+- Agent API can ingest/retrieve/ask/propose.
+- Agent proposals are suggestions, never silent state overrides.
+- Human or policy gate confirms consequential actions.

--- a/next-version/DRY_RUN_MERGE_PATCH_MAP.md
+++ b/next-version/DRY_RUN_MERGE_PATCH_MAP.md
@@ -1,0 +1,34 @@
+# DRY_RUN_MERGE_PATCH_MAP
+
+## Pre-write summary: Adoption Slice A proven vs unproven for real baseline merge
+### Proven in isolated vNext
+- Canonical cockpit flow executes end-to-end through one thin React path.
+- Adapter/controller boundary keeps UI mostly presentational.
+- Retrieval-before-reasoning is enforced through service contracts.
+- Sync/error/status surfaces are explicit and testable.
+
+### Unproven for baseline merge
+- Exact fit with baseline route and shell constraints.
+- Interaction with existing baseline capture/chat/outbox layers without duplication.
+- Baseline-specific lifecycle behavior (web+Capacitor runtime).
+- Incremental integration complexity under existing production code paths.
+
+## Future baseline touch points (dry-run map)
+
+| Baseline target path (expected) | Why touched | Change type | Responsibility in merge | Must remain outside |
+|---|---|---|---|---|
+| `apps/web/src/App.tsx` (or root route entry) | register Slice-A cockpit route/entry surface | modified (minimal) | mount one canonical cockpit entry point | no business logic, no contract validation logic |
+| `apps/web/src/routes/*` or equivalent view container | host cockpit view | new or modified | provide screen/view placement for Slice A only | no sync/retrieval orchestration internals |
+| `apps/web/src/components/*` (capture/review/chat panels) | reuse existing visual sections | wrapped/modified | render UI surfaces for canonical actions | no duplicated flow logic |
+| `apps/web/src/lib/*adapter*` (new) | map baseline UI actions to canonical adapter boundary | new | stable UI-side action/state/error interface | no direct persistence/model rules |
+| `apps/web/src/lib/api*` | wire adapter to existing API client surfaces when needed | wrapped/minimal modified | transport integration only | no canonical flow rules |
+| `apps/web/src/lib/db*` / local store module | ensure status/state surfaces consume existing persistence safely | mostly untouched or minimal read adapter | expose needed status reads | no UI orchestration |
+| `apps/web/src/lib/outbox*` / sync queue module | align visible sync statuses | untouched initially or wrapped | provide sync status signals for cockpit | no new parallel sync engine |
+| `packages/shared/*` (if contract types exist) | shared state/action contract typing | new or minimal modified | contract types only | no runtime orchestration logic |
+| `apps/web/capacitor.config.*` + `apps/web/android/*` | only if route bootstrap/env needs mapping | untouched for slice A | none unless strictly required | no behavioral changes |
+
+## Explicitly left untouched in first real merge
+- backend runtime modules (`server/*`) beyond existing contract consumption
+- model provider wiring
+- non-canonical feature routes
+- advanced analytics/report/report-generation surfaces

--- a/next-version/GUI_COCKPIT_PLAN.md
+++ b/next-version/GUI_COCKPIT_PLAN.md
@@ -1,0 +1,52 @@
+# GUI_COCKPIT_PLAN
+
+## Goal
+Provide the thinnest graphical Human UI over the hardened Slice 1 kernel with no core redesign and no feature expansion.
+
+## Scope (only)
+- Capture
+- Review
+- Correct
+- Sync status
+- Ask
+- Decide
+
+## UX shell structure (thin)
+1. **VisitForm panel**
+   - Input observation/media/location fields.
+   - Save to local Twin event path.
+2. **ReviewCorrect panel**
+   - Show captured values and correction input.
+3. **SyncStatus strip**
+   - Show `queued` or `succeeded` plus timestamp.
+4. **AskTwin panel**
+   - Question box.
+   - Retrieval snapshot summary indicator.
+   - Recommendation + confidence.
+5. **Decision panel**
+   - Accept/modify/reject action.
+
+## Interaction contract
+- UI invokes capability boundary methods only.
+- No direct state mutation outside Twin service contract.
+- Ask button disabled until retrieval context exists.
+- Decision actions append events and finalize visit.
+
+## Minimal data shown
+- visit id
+- current visit state
+- latest sync status
+- retrieval context id
+- recommendation text/confidence
+- decision result
+
+## Explicitly not included
+- multi-screen navigation complexity
+- advanced analytics
+- model/provider selection controls
+- report generation UX
+- batch operations
+
+## Implementation posture
+- Treat GUI as a presentational shell over existing Slice-1 kernel.
+- Keep components stateless where possible; state source remains Twin core via adapter.

--- a/next-version/HUMAN_UI_STRATEGY.md
+++ b/next-version/HUMAN_UI_STRATEGY.md
@@ -1,0 +1,59 @@
+# HUMAN_UI_STRATEGY
+
+## Product stance
+The UI is a **calm operational cockpit**, not the intelligence engine.
+Primary loop: capture → review → correct → sync → ask → decide.
+
+## Key screens
+1. **Dashboard / Today**
+   - Queue health, pending visits, sync status, recent recommendations.
+2. **Capture Visit**
+   - Structured form + media capture + context hints.
+3. **Review & Correct**
+   - Side-by-side source artifacts and extracted fields.
+4. **Sync Center**
+   - Pending/failed/successful sync events with retry actions.
+5. **Ask Twin**
+   - Context-grounded Q&A and recommendation cards.
+6. **Decision & Report**
+   - Approve/modify/reject recommendations and generate shareable summary.
+7. **History / Audit**
+   - Chronological event trail with provenance.
+
+## Navigation principles
+- One primary action per screen.
+- Progressive disclosure for advanced controls.
+- Keep state/status always visible (never hidden behind settings).
+- Use consistent verbs aligned to workflow stages.
+
+## Visible vs hidden
+
+### Must be visible
+- Save status (local persisted/not persisted).
+- Sync state (queued/syncing/failed/synced).
+- Context provenance (what retrieval used).
+- Recommendation confidence and source mode (local-only/hybrid/frontier-assisted).
+
+### Should be hidden by default
+- Raw model/provider tuning knobs.
+- Internal transport/network diagnostics.
+- Secondary automation options that create decision fatigue.
+
+## Confidence / sync / status design
+- Persistent status rail with colored but calm indicators.
+- Every recommendation card must include:
+  - confidence
+  - grounded context summary
+  - last-sync timestamp
+  - override/edit action
+
+## UX simplifications
+1. Single canonical capture form path.
+2. Single sync center (no duplicate retry UIs).
+3. Single assistant entry point tied to retrieval context.
+4. Standardized error language and recovery actions.
+
+## What not to overload into UI
+- Multi-agent orchestration complexity.
+- Provider-specific model mechanics.
+- Infrastructure concerns beyond concise health signals.

--- a/next-version/IMPLEMENTATION_ROADMAP.md
+++ b/next-version/IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,63 @@
+# IMPLEMENTATION_ROADMAP
+
+## Milestone 0 — Isolated next-version workspace
+- **Objective:** protect baseline while enabling focused convergence.
+- **Likely folders:** `next-version/` (architecture + staged implementation scaffolding).
+- **Reuse vs redefine:** reuse baseline as read-only reference; redefine contracts in docs.
+- **Risks:** accidental baseline coupling.
+- **Validation approach:** repository-level checks that baseline remains untouched.
+- **Definition of done:** all vNext artifacts and changes occur only in next-version workspace.
+
+## Milestone 1 — Contract and workflow freeze
+- **Objective:** finalize canonical workflow + Twin/API contracts before coding.
+- **Likely folders:** `next-version/*.md` (this package), plus decision log file.
+- **Reuse vs redefine:** reuse proven baseline primitives; redefine boundaries.
+- **Risks:** over-design without execution feedback.
+- **Validation approach:** architecture review checklist against baseline reality.
+- **Definition of done:** approved canonical flow, state model, and API capabilities.
+
+## Milestone 2 — Choose single sync path
+- **Objective:** plan migration to one queue/outbox engine.
+- **Likely folders (future implementation):** `apps/web/src/lib/outbox*`, `apps/web/src/lib/queues/*`, capture/sync call sites.
+- **Reuse vs redefine:** reuse strongest existing implementation; deprecate duplicate path.
+- **Risks:** retry/conflict regressions.
+- **Validation approach:** scenario matrix (offline capture, reconnect sync, conflict retry).
+- **Definition of done:** one sync engine contract and migration plan with rollback steps.
+
+## Milestone 3 — Choose single API client boundary
+- **Objective:** one canonical client contract for chat/retrieval/sync calls.
+- **Likely folders (future implementation):** `apps/web/src/lib/api*.ts`, assistant call sites.
+- **Reuse vs redefine:** reuse stable parser/transport pieces; redefine public client interface.
+- **Risks:** stream compatibility issues.
+- **Validation approach:** API contract tests + end-to-end assistant smoke tests.
+- **Definition of done:** one client module exported and consumed everywhere.
+
+## Milestone 4 — Twin capability API façade
+- **Objective:** map existing backend primitives to capability-centric endpoints.
+- **Likely folders (future implementation):** backend route layer + typed contract docs.
+- **Reuse vs redefine:** reuse current backend internals; redefine external contract names.
+- **Risks:** endpoint churn and temporary duplication.
+- **Validation approach:** capability test suite (`ingest_visit`, `retrieve_context`, `ask_twin`, etc.).
+- **Definition of done:** stable vNext API surface with explicit side effects.
+
+## Milestone 5 — Cockpit UX convergence
+- **Objective:** implement calm UX loop (capture/review/correct/sync/ask/decide).
+- **Likely folders (future implementation):** app shell, field visit screens, sync center, assistant panel.
+- **Reuse vs redefine:** reuse existing components where behavior aligns; simplify navigation/state surfaces.
+- **Risks:** UX scope creep.
+- **Validation approach:** task-based walkthroughs + status visibility checklist.
+- **Definition of done:** operators can complete core loop without ambiguous states.
+
+## Milestone 6 — Release/runbook alignment
+- **Objective:** reconcile docs/scripts with actual architecture.
+- **Likely folders (future implementation):** startup scripts, deployment docs, status docs.
+- **Reuse vs redefine:** reuse current scripts where possible; remove contradictory instructions.
+- **Risks:** environment-specific script differences.
+- **Validation approach:** clean-room setup verification on documented commands.
+- **Definition of done:** one truthful runbook for dev/test/deploy and no doc-code drift.
+
+## What NOT to do during roadmap execution
+- Do not add new model providers before core flow convergence.
+- Do not add new wearable integrations before contract stabilization.
+- Do not rewrite stack layers that can be consolidated safely.
+- Do not expose ungrounded reasoning outputs as operational truth.

--- a/next-version/INTEGRATION_BLUEPRINT.md
+++ b/next-version/INTEGRATION_BLUEPRINT.md
@@ -1,0 +1,55 @@
+# INTEGRATION_BLUEPRINT
+
+## Purpose
+Define how the hardened vNext Slice 1 kernel can map into the real Multimodal-Agentic-Farm-Visit evolution path, while baseline remains unchanged for now.
+
+## 1) Baseline-to-kernel mapping
+
+### vNext kernel assets (current)
+- `vnext_twin_core/`: event contracts, state transitions, sync semantics, retrieval-before-reasoning enforcement.
+- `vnext_api/`: capability façade over the same Twin service.
+- `vnext_ui/cli.py`: reference operational flow and contract behavior.
+
+### Baseline areas that can adopt kernel ideas first
+1. **Local persistence + sync semantics (apps/web/src/lib)**
+   - Adopt event contract vocabulary and status semantics (`draft/reviewed/finalized`, `queued/succeeded`).
+   - Converge duplicated outbox/queue logic to one contract-first sync path.
+2. **App-layer orchestration (apps/web/src/components + hooks)**
+   - Align to one canonical workflow: capture→review/correct→save→sync→retrieve→ask→decide.
+3. **API boundary**
+   - Add capability-level interface adapter over existing backend endpoints (`sync`, `rag`, chat), keeping retrieval-before-reasoning rule.
+4. **Validation discipline**
+   - Port Slice-1 acceptance checks into baseline CI/dev checks incrementally.
+
+## 2) Baseline parts to keep untouched for now
+- Existing Capacitor Android implementation internals.
+- Existing backend runtime internals (`server/rag_service`) unless needed for contract alignment.
+- Existing model/provider implementation details.
+- Any Slice 2+ functionality and experimentation paths.
+
+Reason: preserve delivery continuity while contracts and orchestration are stabilized.
+
+## 3) Where future React/Capacitor UI sits
+Future graphical UI should be a **thin shell over the same kernel semantics**:
+- Presentation/UI state in React.
+- Core workflow and contract logic delegated to a shared service boundary (frontend adapter of Twin capabilities).
+- Capacitor layer remains transport/device integration only.
+
+## 4) Where future real backend/RAG sits
+- Backend remains implementation of persistence/sync/retrieval services.
+- Retrieval endpoints provide grounded context snapshots.
+- Model/reasoning calls happen only after retrieval contract is satisfied.
+- Backend must not become source of truth that bypasses Twin event semantics.
+
+## 5) Safest migration path
+1. Keep kernel isolated as reference contract engine.
+2. Adopt contracts in baseline docs + adapter interfaces first.
+3. Introduce service boundary wrappers in baseline (without replacing internals initially).
+4. Migrate one baseline workflow path to canonical flow behind feature flag.
+5. Expand only after acceptance criteria pass repeatedly.
+
+## 6) Non-negotiables
+- One canonical workflow only.
+- Twin core semantics as operational truth.
+- Retrieval-before-reasoning always enforced.
+- Staged adoption over rewrite.

--- a/next-version/LOCAL_RAG_VS_FRONTIER_REASONING.md
+++ b/next-version/LOCAL_RAG_VS_FRONTIER_REASONING.md
@@ -1,0 +1,35 @@
+# LOCAL_RAG_VS_FRONTIER_REASONING
+
+## Decision split
+
+## What stays local (operational truth)
+- Visit/observation/media canonical records.
+- Sync queue/outbox state and retry history.
+- Audit trail and correction history.
+- Local index/embeddings where feasible for offline retrieval.
+
+## What retrieval does
+- Assembles relevant context from Twin memory.
+- Produces ranked, provenance-rich retrieval snapshots.
+- Enforces grounding boundary for downstream reasoning.
+
+## What frontier reasoning does
+- Synthesis: summarize cross-event patterns.
+- Interpretation: infer likely causes and implications.
+- Planning: propose next actions/report narratives.
+
+## Source of truth
+- Twin memory/events are source of truth.
+- Model outputs are advisory artifacts unless accepted and written back as events.
+
+## What should never bypass grounding
+- Recommendations.
+- Risk/priority scoring shown to operators.
+- Generated reports sent externally.
+- Any automated action proposal.
+
+## Privacy / latency / offline implications
+- Local-first mode protects continuity and minimizes network dependency.
+- Frontier calls are optional and policy-gated.
+- System degrades gracefully: retrieval + local heuristics when cloud unavailable.
+- Sensitive data can remain local while sharing only minimal grounded context upstream.

--- a/next-version/MERGE_STRATEGY.md
+++ b/next-version/MERGE_STRATEGY.md
@@ -1,0 +1,44 @@
+# MERGE_STRATEGY
+
+## Objective
+Define smallest staged adoption of hardened Slice 1 kernel into real product direction with explicit rollback points.
+
+## Stage 0 — Keep isolated (current)
+- Keep `next-version/` as reference kernel and contract source.
+- Baseline untouched.
+- Exit criteria: stable contract docs + passing Slice-1 tests.
+- **Rollback point:** no-op (already isolated).
+
+## Stage 1 — Contract adoption
+- Adopt contract vocabulary and invariants in baseline docs/interfaces:
+  - event types
+  - state transitions
+  - sync outcomes
+  - retrieval-before-reasoning precondition
+- No behavior replacement yet.
+- **Risks:** doc drift if not enforced.
+- **Rollback point:** revert docs/interface adapters only.
+
+## Stage 2 — Service boundary adoption
+- Add thin adapter layer in baseline that mirrors kernel capabilities (`ingest_visit`, `sync_event`, `retrieve_context`, `ask_twin`, ...).
+- Route one canonical path through adapter while keeping existing internals behind it.
+- **Risks:** duplicated execution paths during transition.
+- **Rollback point:** disable adapter path via feature flag and return to current baseline path.
+
+## Stage 3 — UI adoption
+- Introduce thin graphical cockpit for canonical flow only.
+- Bind UI actions to stage-2 capability boundary.
+- Keep advanced/legacy routes hidden or out of scope.
+- **Risks:** UX confusion if old/new flows coexist visibly.
+- **Rollback point:** switch UI routing back to legacy view while retaining adapter contracts.
+
+## Stage 4 — Retrieval/model integration
+- Connect real backend retrieval snapshots and reasoning providers behind same contracts.
+- Preserve retrieval-before-reasoning enforcement in service boundary.
+- **Risks:** grounding bypass, latency spikes, partial failures.
+- **Rollback point:** pin reasoning to local stub/fallback while keeping retrieval + event persistence stable.
+
+## Cross-stage controls
+- Feature flags per stage boundary.
+- Acceptance checklist must pass before advancing stage.
+- No Slice 2 scope until stage 4 is stable.

--- a/next-version/MINIMAL_BASELINE_DIFF_PLAN.md
+++ b/next-version/MINIMAL_BASELINE_DIFF_PLAN.md
@@ -1,0 +1,38 @@
+# MINIMAL_BASELINE_DIFF_PLAN
+
+## Objective
+Define smallest possible baseline diff for first integration attempt of Adoption Slice A.
+
+## Minimum viable merge slice (dry-run)
+1. Add one cockpit route/view container.
+2. Add one UI adapter module that mirrors vNext action/state contract.
+3. Reuse existing baseline visual components for capture/review/chat/status where possible.
+4. Wire only canonical action buttons/handlers to adapter.
+5. Preserve existing backend/persistence modules unchanged unless a tiny wrapper is required.
+
+## Exact components/modules likely involved
+- `apps/web/src/App.tsx` or route registry file (single new route link)
+- `apps/web/src/views/CockpitSliceA.*` (new thin container)
+- `apps/web/src/lib/cockpitAdapter.*` (new minimal adapter/glue)
+- `apps/web/src/components/*` existing panels reused by composition
+- optional `packages/shared/*` for shared contract type definitions
+
+## Exact adapter/glue points
+- UI event handlers call adapter methods only:
+  - start_visit, capture, review_correct, save_local, sync, retrieve, ask, decide
+- Adapter returns stable state surface:
+  - visitId, sliceState, localSaveStatus, syncStatus, retrievalSummary, recommendation, lastError
+- Adapter mediates transport and preserves retrieval-before-reasoning error semantics.
+
+## Exact surfaces that must NOT be changed
+- core sync/outbox internals (except read-only status wrapping)
+- backend model/retrieval runtime behavior
+- non-canonical routes/features
+- global styling system
+- Capacitor runtime config (unless route boot requires trivial update)
+
+## Why this is minimum
+- Adds only one new user-visible path.
+- Avoids touching deep kernel/backend internals.
+- Keeps rollback to route+adapter removal.
+- Prevents parallel workflow proliferation by confining scope to one canonical cockpit path.

--- a/next-version/NEXT_DECISION.md
+++ b/next-version/NEXT_DECISION.md
@@ -1,0 +1,25 @@
+# NEXT_DECISION
+
+## Recommendation
+**A) Integration planning first** (then thin GUI), not backend-first.
+
+## Why this is the best next move
+1. The kernel is now contract-hardened and testable, but still isolated.
+2. Jumping to real backend or GUI integration without explicit staged merge boundaries risks reintroducing drift and parallel paths.
+3. Integration planning first enables safe feature-flagged adoption and clear rollback points.
+4. It preserves the core non-negotiables:
+   - Twin core centrality
+   - one canonical workflow
+   - retrieval-before-reasoning
+
+## Practical sequence after this decision
+1. Approve `INTEGRATION_BLUEPRINT.md` + `MERGE_STRATEGY.md`.
+2. Execute Stage 1 contract adoption in baseline-facing interfaces/docs.
+3. Build the thin GUI shell only once stage-2 service boundary is in place.
+4. Defer real backend/model wiring until stage-4 controls are ready.
+
+## Why not B (thin GUI first)
+GUI-first can mask unresolved service/contract boundaries and create coupling that is expensive to unwind.
+
+## Why not C (real backend first)
+Backend-first without staged boundary adoption risks bypassing kernel contracts and duplicating orchestration logic.

--- a/next-version/NEXT_EXECUTION_RECOMMENDATION.md
+++ b/next-version/NEXT_EXECUTION_RECOMMENDATION.md
@@ -1,0 +1,23 @@
+# NEXT_EXECUTION_RECOMMENDATION
+
+## Recommendation
+**B) Perform a tiny real baseline integration spike.**
+
+## Why B is best now
+- Dry-run planning is sufficiently detailed and constrained.
+- Isolated Slice-A behavior is already stable and tested.
+- The highest remaining uncertainty is baseline fit (route/shell/adapter placement), which only a tiny controlled spike can validate.
+- A tightly scoped spike can remain reversible (route + adapter + one cockpit container).
+
+## Spike scope guardrails
+1. One cockpit route only.
+2. One adapter boundary only.
+3. No backend/model changes.
+4. No non-canonical feature exposure.
+5. Abort on first boundary-leakage signal.
+
+## Why not A now
+Continuing dry-run only adds diminishing returns without reducing baseline integration uncertainty.
+
+## Why not C now
+Isolated repo refactor is not the bottleneck; baseline fit and integration friction are.

--- a/next-version/NEXT_VERSION_ARCHITECTURE.md
+++ b/next-version/NEXT_VERSION_ARCHITECTURE.md
@@ -1,0 +1,89 @@
+# NEXT_VERSION_ARCHITECTURE
+
+## Executive summary
+The next version should be built as an **Agentic Digital Twin** with two interfaces over one shared core:
+1. Human-facing operational cockpit
+2. Agent-facing capability APIs
+
+The Twin core (memory + retrieval context + audit history) is the product center. Reasoning models are optional synthesis layers after retrieval, never the system of record.
+
+## Present-state interpretation of baseline repo
+From baseline inspection, the system already contains the key primitives but with drift:
+- Working web shell and capture flow.
+- Local persistence and queue/outbox mechanisms.
+- FastAPI RAG backend with sync/media/retrieval endpoints.
+- Capacitor Android bridge and CI scripts.
+
+Contradictions and drift to resolve:
+- Documentation claims backend gaps while backend code exists.
+- Multiple parallel sync/API paths coexist.
+- README claims exceed visible implementation in some integrations.
+
+## Future-state architecture
+
+### 1) Human UI (operational cockpit)
+Purpose: field operations, correction, decision support.
+
+Responsibilities:
+- Capture/review/correct/save/sync/ask/decide loop.
+- Explicit state visibility (local saved, queued, synced, retrieval-ready, recommendation-issued).
+- Minimal cognitive load and clear recovery actions.
+
+### 2) Agent-facing APIs (first-class interface)
+Purpose: machine-usable access to the same Twin core.
+
+Responsibilities:
+- Capability endpoints (`ingest_visit`, `retrieve_context`, `ask_twin`, etc.).
+- Stable schemas and explicit side effects.
+- Shared governance rules with UI flows.
+
+### 3) Twin core (shared operational memory)
+Purpose: single source of operational truth.
+
+Responsibilities:
+- Event history (visits, corrections, recommendations, reports).
+- Media and structured records.
+- Embeddings, retrieval traces, sync history, audit log.
+
+### 4) Sync and ingestion layer
+Purpose: deterministic local-first write path + robust eventual sync.
+
+Responsibilities:
+- Single canonical outbox/queue engine.
+- Idempotent sync events and conflict resolution policy.
+- Explicit failure states and retry semantics.
+
+### 5) Retrieval / RAG layer
+Purpose: assemble grounded context slices from Twin memory.
+
+Responsibilities:
+- Text/media retrieval over local+backend index.
+- Retrieval snapshots that are persisted for auditability.
+- Relevance thresholding and provenance.
+
+### 6) Reasoning/model layer
+Purpose: synthesize recommendations from retrieved context.
+
+Responsibilities:
+- Perform interpretation/planning/reporting after retrieval.
+- Never mutate source memory without explicit event writes.
+- Capture model inputs/outputs metadata in audit trail.
+
+## Main architectural simplifications
+1. Converge to one canonical workflow (remove parallel paths).
+2. Converge to one sync engine and one API client boundary.
+3. Treat docs as versioned contracts tied to code reality.
+4. Separate Twin memory truth from model reasoning outputs.
+5. Normalize UI and Agent APIs to the same capability contract.
+
+## Must reuse from baseline
+- Local persistence primitives and offline-first posture.
+- Existing sync/media/RAG backend primitives.
+- Existing capture components and mobile bridge foundation.
+- Existing deployment/build scripts as starting assets.
+
+## Must not be carried forward
+- Competing sync pathways in active use.
+- Multiple overlapping API clients for same operations.
+- Ambiguous doc claims not backed by code.
+- UI logic that hides system state transitions.

--- a/next-version/NORTH_STAR_SUMMARY.md
+++ b/next-version/NORTH_STAR_SUMMARY.md
@@ -1,0 +1,91 @@
+# NORTH_STAR_SUMMARY
+
+## vNext north star
+Build **one coherent Agentic Digital Twin system** where:
+- The **Twin core** is the source of operational truth.
+- The **Human UI** and **Agent API** are two interfaces to the same memory/state.
+- **Retrieval (RAG) grounds context first**, then reasoning generates recommendations.
+- Model outputs are advisory until accepted and written back as Twin events.
+
+## Canonical product loop (single flow)
+Reality → Capture → Review → Correct → Save Local Twin Event → Sync → Retrieve Context → Ask/Reason → Decide → Write-back Feedback Event
+
+This is the only primary workflow for vNext.
+
+## Human UI strategy in one page
+The UI is a calm operational cockpit with six stable verbs:
+1. Capture
+2. Review
+3. Correct
+4. Sync
+5. Ask
+6. Decide
+
+UI responsibilities:
+- Make state visible: local save status, sync status, recommendation confidence, provenance.
+- Reduce cognitive load: one primary action per screen, progressive disclosure for advanced controls.
+- Keep operational continuity in offline mode.
+
+## Twin state model summary
+The Twin is event-centric and append-first.
+Core event/entity classes:
+- visit_event
+- observation
+- media_asset
+- location_context
+- sync_event
+- retrieval_context
+- recommendation_event
+- user_correction_event
+- report_snapshot_event
+- audit_history_event
+
+Principle:
+- Current state is derived from latest validated events.
+- Corrections append events (no destructive overwrite).
+
+## Agent API strategy summary
+Expose capability APIs over the same Twin core:
+- ingest_visit
+- upload_media
+- sync_event
+- retrieve_context
+- ask_twin
+- get_entity_history
+- generate_report
+- propose_next_action
+
+Contract rule:
+- Any recommendation/report/action proposal must be grounded by retrieval first.
+
+## Local RAG vs frontier reasoning split
+### Local layer owns
+- operational memory truth (events/media/sync/audit)
+- local-first writes
+- baseline retrieval capability (including offline path where possible)
+
+### Frontier layer owns
+- higher-order synthesis
+- planning and recommendation generation
+- narrative report generation
+
+Safety rule:
+- frontier reasoning cannot bypass grounding or silently mutate Twin truth.
+
+## Phased roadmap synthesis
+1. **M0 — Workspace isolation**: keep all vNext work in next-version workspace.
+2. **M1 — Contract freeze**: lock workflow/state/API contracts before code.
+3. **M2 — Sync convergence**: move to one canonical sync engine.
+4. **M3 — API client convergence**: one canonical client boundary.
+5. **M4 — Capability façade**: expose stable Twin capability APIs.
+6. **M5 — Cockpit convergence**: implement the calm UX loop.
+7. **M6 — Runbook truthing**: align scripts/docs with actual behavior.
+
+## Explicit non-goals for first implementation phase
+- No new model providers.
+- No wearable expansion.
+- No broad multi-agent orchestration layer.
+- No stack rewrite.
+
+## Success signal
+A field manager can complete one end-to-end visit loop (capture→decision) with clear status, no ambiguous sync state, grounded recommendations, and auditable write-back into Twin history.

--- a/next-version/PORTING_NOTES.md
+++ b/next-version/PORTING_NOTES.md
@@ -1,0 +1,33 @@
+# PORTING_NOTES
+
+## Temporary (Tkinter-specific) parts
+- `vnext_ui/gui.py` widget layout and event wiring.
+- Tkinter `StringVar`/`BooleanVar` state containers.
+- Desktop window lifecycle assumptions.
+
+These should be translated to React components/hooks, not copied directly.
+
+## Permanent behavioral references
+- `CockpitController` action semantics and state surface.
+- `safe_call` pattern for contract-safe UI interactions.
+- Canonical action ordering and state progression.
+- Retrieval-before-reasoning contract behavior and user-facing error semantics.
+
+## Reuse directly (or near-direct)
+- `vnext_twin_core/*` core logic and contracts (as-is reference behavior).
+- `vnext_api/capabilities.py` capability interface semantics.
+- Existing tests for kernel behavior (`test_slice1.py`) as regression anchor.
+- GUI-controller tests (`test_gui_controller.py`) as UI-contract behavior anchor.
+
+## Translate, not copy
+- Controller class -> React hook/service adapter
+- Flat Tkinter form layout -> minimal React cockpit panels
+- Tkinter status labels -> persistent status strip/cards
+- Tkinter event callbacks -> handler functions invoking capability boundary
+
+## Porting guardrails
+1. Do not move business rules into React components.
+2. Do not alter core contracts during UI port.
+3. Do not add non-slice functionality.
+4. Keep error and status surfaces explicit and visible.
+5. Preserve one canonical flow only.

--- a/next-version/PRE_COMMIT_MILESTONE_CHECK.md
+++ b/next-version/PRE_COMMIT_MILESTONE_CHECK.md
@@ -1,0 +1,36 @@
+# PRE_COMMIT_MILESTONE_CHECK
+
+Date: 2026-03-23
+Scope: Safe repo only (`next-version/`), no upstream baseline modifications.
+
+## Check results
+1. **Adoption Slice A within minimum diff plan**: PASS
+   - Spike limited to baseline-shaped route serving + thin adapter-preserving UI surface.
+2. **Rollback trigger hit**: NO
+   - No boundary leakage, no duplicate workflow path introduced in spike surface.
+3. **Canonical workflow holds**: PASS
+   - Start → Capture → Review/Correct → Save → Sync → Retrieve → Ask → Decide remains intact.
+4. **Retrieval-before-reasoning enforced**: PASS
+   - Ask before retrieval returns contract error (`retrieval_context is required before reasoning`).
+5. **Sync/error/status surfaces explicit**: PASS
+   - Sync state (`queued`/`succeeded`) and `last_error` remain exposed.
+6. **Business logic leak into UI**: NO
+   - UI routes through adapter/controller boundaries.
+7. **Relevant tests green**: PASS
+   - `python -m unittest discover -s next-version/tests -p 'test_*.py'` passes.
+8. **Deferred items remain deferred**: PASS
+   - No real backend/model/multimodal/Slice-B changes introduced.
+
+## Exact files changed in Adoption Slice A spike
+- `next-version/README.md`
+- `next-version/tests/test_react_api.py`
+- `next-version/vnext_ui/react_api.py`
+- `next-version/vnext_ui/react_cockpit/baseline_shape/index.html`
+- `next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/AppShell.js`
+- `next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/lib/cockpitAdapter.js`
+- `next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/views/CockpitSliceA.js`
+
+## Remaining risks
+- Baseline route/shell fit is still unproven until tiny real baseline spike occurs.
+- Potential mismatch with baseline component boundaries may require adapter refinement.
+- Browser-runtime constraints in this environment limit visual/manual verification depth.

--- a/next-version/REACT_COCKPIT_ADOPTION_PLAN.md
+++ b/next-version/REACT_COCKPIT_ADOPTION_PLAN.md
@@ -1,0 +1,65 @@
+# REACT_COCKPIT_ADOPTION_PLAN
+
+## Pre-doc summary: what Tkinter cockpit proved vs did not prove
+### Proved
+- Canonical Slice-1 workflow can run end-to-end through one UI path.
+- UI can remain thin over shared contracts (`TwinCapabilities` + `TwinService`).
+- Retrieval-before-reasoning can be enforced at service boundary and reflected in UI errors.
+- Sync status and state progression can be surfaced clearly with minimal UI complexity.
+
+### Did not prove
+- Mobile/web production UX quality.
+- React/Capacitor lifecycle behavior (routing, background/foreground resume).
+- Real backend transport/model latency/failure behavior.
+- Performance/scaling beyond Slice-1 local flow.
+
+## Objective
+Translate current Tkinter cockpit behavior into React/Capacitor architecture without changing Twin core contracts or expanding scope.
+
+## Mapping: Tkinter cockpit -> React/Capacitor
+
+| Current element | React/Capacitor equivalent | Notes |
+|---|---|---|
+| `CockpitController` | `useCockpitController` hook + small service adapter | Keep orchestration thin; no business logic in components |
+| `CockpitState` | React state model (single screen state atom) | UI state mirrors service results; source of truth remains Twin core |
+| Button handlers (`on_start`, `on_capture`, …) | Component actions calling capability adapter | Preserve action sequence exactly |
+| Status labels | Persistent status strip/cards | Same state surfaces: visit id, slice state, save, sync, retrieval, recommendation |
+| `safe_call` error handling | Unified error mapper in UI adapter | Show user-readable error text, no stack traces |
+
+## Boundaries that must remain unchanged
+1. `TwinService` owns workflow validity and state transitions.
+2. `TwinCapabilities` remains the UI-facing capability boundary.
+3. Retrieval-before-reasoning is enforced by service contract, not UI-only checks.
+4. UI never writes persistence directly; it invokes capability/service methods only.
+
+## UI state vs Twin core state
+### UI-local state
+- form input buffers (observation, correction, question)
+- transient view state (loading, disabled controls, panel focus)
+- presentational status formatting
+
+### Twin/core state (authoritative)
+- visit lifecycle state (`draft/reviewed/finalized`)
+- persisted events
+- sync outcome state (`queued/succeeded`)
+- retrieval context ids and recommendation linkage
+
+## Preserving canonical flow exactly
+Required action order:
+1. start visit
+2. capture
+3. review/correct
+4. save local
+5. sync
+6. retrieve
+7. ask/reason
+8. decide/finalize
+
+UI must not expose alternate workflow routes in Slice-1 port.
+
+## Deferred in React adoption
+- multipage navigation and advanced information architecture
+- auth/session flows
+- background sync conflict handling
+- provider/model selection UI
+- Slice 2 features and analytics surfaces

--- a/next-version/README.md
+++ b/next-version/README.md
@@ -1,0 +1,62 @@
+# Twin vNext Core Product (Official)
+
+This directory is the official Twin-centered vNext core product line.
+
+It contains the hardened Slice-1 kernel and thin interfaces over shared contracts.
+
+## What is implemented now
+
+- Canonical Slice-1 journey through thin interfaces over one core:
+  - CLI (`vnext_ui/cli.py`)
+  - Tkinter cockpit (`vnext_ui/gui.py`)
+  - React cockpit (`vnext_ui/react_api.py` + `vnext_ui/react_cockpit/*`)
+- Baseline-shaped spike route (`/baseline`) serving app-shaped cockpit structure under:
+  - `react_cockpit/baseline_shape/apps/web/src/*`
+- Baseline-aligned adapter boundary (`vnext_ui/baseline_adapter.py`) keeps UI thin and logic centralized.
+- Shared Twin core (`vnext_twin_core`) as source of truth.
+- Shared capability façade (`vnext_api`) used by all UI paths.
+- Explicit state transitions (`draft` → `reviewed` → `finalized`) with contract checks.
+- Single-path sync outcomes: offline=`queued`, online=`succeeded`.
+- Retrieval-before-reasoning enforced.
+- User-readable error surfacing across UI paths.
+
+## Canonical scope in this line
+
+Implemented flow:
+
+- Start visit
+- Capture observation
+- Review/correct
+- Save local
+- Sync + visible status
+- Retrieve context
+- Ask/reason (grounded)
+- Decide + result summary
+
+No expansion beyond this canonical flow in the current phase.
+
+## Run and validate
+
+From repository root:
+
+```bash
+python next-version/vnext_ui/cli.py
+python next-version/vnext_ui/cli.py --offline
+python next-version/vnext_ui/gui.py
+PYTHONPATH=next-version python -m vnext_ui.react_api
+python -m unittest discover -s next-version/tests -p 'test_*.py'
+```
+
+Then open:
+
+- `http://127.0.0.1:8765` (thin cockpit)
+- `http://127.0.0.1:8765/baseline` (baseline-shaped spike cockpit)
+
+## Deferred intentionally
+
+- Real HTTP backend transport/auth
+- Real multimodal retrieval/embeddings
+- Real frontier-model calls
+- Advanced sync conflict resolution
+- Report templating
+- Slice B / Slice 2 features

--- a/next-version/REAL_BASELINE_SPIKE_BLOCKED_PATH.md
+++ b/next-version/REAL_BASELINE_SPIKE_BLOCKED_PATH.md
@@ -1,0 +1,46 @@
+# REAL_BASELINE_SPIKE_BLOCKED_PATH
+
+## 1) Local repo path confirmation
+Requested path: `C:\Users\Atilio\projects\agents\7_farm_visit`
+
+Observed from this environment:
+- Current workspace root: `/workspace/Codex-Test`
+- `/mnt/c/Users/Atilio/projects/agents/7_farm_visit` not present
+- `C:/Users/Atilio/projects/agents/7_farm_visit` not present
+- `/workspace` contains only `Codex-Test`
+
+Conclusion: the requested baseline checkout path is not mounted/accessible in this execution environment.
+
+## 2) Isolated branch/worktree creation
+Blocked because baseline repository path is unavailable, so no branch/worktree can be created here.
+
+## 3) Intended tiny-spike file touch list (once path is available)
+- `apps/web/src/App.tsx` (or route registry equivalent): add single cockpit entry route
+- `apps/web/src/views/CockpitSliceA.*`: thin cockpit container
+- `apps/web/src/lib/cockpitAdapter.*`: thin adapter bridge
+- Minimal run-note update in baseline README/docs for the spike route only
+
+## 4) Intended validation commands (once path is available)
+- `pnpm install` (if needed and not already installed)
+- `pnpm --filter @farm-visit/web run dev` (or baseline-equivalent web dev command)
+- `pnpm --filter @farm-visit/web run build`
+- `pnpm --filter @farm-visit/web run type-check` (if present)
+- Existing repo tests/lint command(s)
+- Spike-specific route/action checks for:
+  - canonical flow reachability
+  - retrieval-before-reasoning failure path
+  - sync status visibility
+  - clear error surfacing
+
+## 5) Rollback triggers to watch
+- Any route exposes parallel workflow paths
+- Ask/reason succeeds before retrieval context
+- UI components accumulate transition/validation business logic
+- Spike requires unexpected backend/model integration changes
+- Scope grows beyond route + adapter + thin view container
+
+## Why implementation stopped
+Per constraints, implementing the real baseline spike requires editing the real baseline repo only. Since that repo path is unavailable here, proceeding in `Codex-Test` would violate scope and produce non-actionable changes.
+
+## Smallest corrective action required
+Mount or provide access to the local baseline checkout at `C:\Users\Atilio\projects\agents\7_farm_visit` (or provide the accessible in-container path), then I can execute the tiny spike exactly as requested.

--- a/next-version/RISKS_OF_EARLY_MERGE.md
+++ b/next-version/RISKS_OF_EARLY_MERGE.md
@@ -1,0 +1,43 @@
+# RISKS_OF_EARLY_MERGE
+
+## 1) Boundary leakage
+**Risk:** React components start embedding service/business rules.
+
+**Failure mode:** kernel contracts become optional and diverge from UI behavior.
+
+**Mitigation:** keep action orchestration in adapter/controller boundary only.
+
+## 2) Duplicated workflow paths
+**Risk:** legacy and canonical flows are both visible during migration.
+
+**Failure mode:** users enter inconsistent states; test coverage becomes ambiguous.
+
+**Mitigation:** feature-flag one canonical cockpit route and hide alternatives in Slice A.
+
+## 3) UI/business-logic duplication
+**Risk:** validation/state transition logic copied into UI handlers.
+
+**Failure mode:** contract drift and contradictory error behavior.
+
+**Mitigation:** UI performs only minimal input checks; authoritative validation stays in core/contracts.
+
+## 4) Premature backend coupling
+**Risk:** direct backend payloads shape UI state too early.
+
+**Failure mode:** UI tightly coupled to unstable backend internals; harder staged adoption.
+
+**Mitigation:** maintain adapter surface with stable cockpit state fields independent of backend payload details.
+
+## 5) Styling-driven scope creep
+**Risk:** visual redesign expands before behavioral parity is locked.
+
+**Failure mode:** slow delivery, hidden regressions in canonical flow.
+
+**Mitigation:** clarity-only styling in Slice A; postpone design-system work until flow parity is stable.
+
+## 6) Retrieval-before-reasoning regression
+**Risk:** ask action triggered without grounded retrieval context.
+
+**Failure mode:** ungrounded recommendations and contract violation.
+
+**Mitigation:** enforce at service boundary and verify through adapter tests in each adoption stage.

--- a/next-version/ROLLBACK_AND_ABORT_RULES.md
+++ b/next-version/ROLLBACK_AND_ABORT_RULES.md
@@ -1,0 +1,34 @@
+# ROLLBACK_AND_ABORT_RULES
+
+## Stop-merge conditions (abort immediately)
+1. Canonical flow cannot be completed without fallback to legacy path.
+2. Ask/reason can execute without retrieval context in any integrated path.
+3. UI components begin implementing or duplicating transition/validation logic.
+4. A second competing workflow becomes visible to end users.
+5. Merge requires unexpected backend/model changes beyond agreed tiny wrappers.
+
+## Boundary leakage signals
+- React components referencing persistence/sync internals directly.
+- UI handling state transitions that should remain in controller/service.
+- Adapter bypassed by direct calls into legacy APIs from cockpit actions.
+
+## Workflow duplication signals
+- Two visible action paths for capture→review→save→sync→ask→decide.
+- Duplicate status widgets showing conflicting sync/retrieval states.
+
+## UI/business logic duplication signals
+- Validation rules repeated in component layer and adapter layer.
+- Different error messages/conditions between cockpit and core contracts.
+
+## Revert immediately when
+- retrieval-before-reasoning invariant fails in integration tests.
+- sync status surface diverges from adapter contract (`queued/succeeded` visibility breaks).
+- cockpit route requires broad refactor of unrelated baseline screens.
+
+## Independent rollback units
+1. cockpit route registration
+2. cockpit view container
+3. cockpit adapter module
+4. optional shared type additions
+
+Rollback in reverse order to preserve baseline stability.

--- a/next-version/SCREEN_FLOW_MAP.md
+++ b/next-version/SCREEN_FLOW_MAP.md
@@ -1,0 +1,56 @@
+# SCREEN_FLOW_MAP
+
+## Goal
+Define minimum React/Capacitor screen/view flow preserving current Slice-1 cockpit behavior.
+
+## Minimal view structure
+
+## View 1: Start Visit
+- Primary action: `Start Visit`
+- Output surfaces: visit id, initial state (`draft`)
+
+## View 2: Capture
+- Input: observation text (plus placeholder capture metadata)
+- Primary action: `Capture`
+- Output surfaces: captured observation summary
+
+## View 3: Review/Correct
+- Input: correction text
+- Primary action: `Review + Correct`
+- Output surfaces: corrected summary, state now `reviewed`
+
+## View 4: Save + Sync Status
+- Actions: `Save Local`, `Sync` (online toggle)
+- Output surfaces:
+  - local save status
+  - sync status (`queued`/`succeeded`)
+
+## View 5: Retrieve + Ask
+- Inputs: retrieval question, ask question
+- Actions: `Retrieve`, then `Ask`
+- Output surfaces:
+  - retrieval summary + retrieval id
+  - recommendation text/confidence (if available)
+
+## View 6: Decide
+- Input: decision (`accepted|modified|rejected`)
+- Action: `Decide`
+- Output: state finalized
+
+## View 7: Result / History Summary (minimal)
+- Read-only summary panel of current run:
+  - visit id
+  - state
+  - save/sync statuses
+  - retrieval summary/id
+  - recommendation
+  - decision
+
+## Navigation rules
+- Sequential stepper or single-page sections allowed.
+- No extra screens unless required for this exact flow.
+- No branching routes that bypass required steps.
+
+## Persistent shell elements
+- top status strip (visit id, state, sync)
+- error banner area (`lastError`)

--- a/next-version/TWIN_API_CONTRACT.md
+++ b/next-version/TWIN_API_CONTRACT.md
@@ -1,0 +1,70 @@
+# TWIN_API_CONTRACT
+
+## Contract principles
+- Capability-based API over shared Twin core.
+- Explicit side effects and provenance.
+- Retrieval-first rule for any reasoning capability.
+
+## 1) ingest_visit
+- **Purpose:** create/update visit_event and observations.
+- **Input:** visit metadata, observations, optional local IDs and timestamps.
+- **Output:** canonical visit_id, accepted fields, validation warnings.
+- **Side effects:** writes visit_event + observation events.
+- **Execution mode:** hybrid (local-first, backend-sync).
+- **Retrieval grounding required first?** No.
+
+## 2) upload_media
+- **Purpose:** register and store media assets.
+- **Input:** media metadata + payload reference.
+- **Output:** media_id, storage refs, index status.
+- **Side effects:** writes media_asset, may enqueue embedding.
+- **Execution mode:** hybrid.
+- **Retrieval grounding required first?** No.
+
+## 3) sync_event
+- **Purpose:** synchronize local events with backend.
+- **Input:** object ref, direction, payload hash, last attempt context.
+- **Output:** sync state + conflict details if any.
+- **Side effects:** writes sync_event.
+- **Execution mode:** hybrid.
+- **Retrieval grounding required first?** No.
+
+## 4) retrieve_context
+- **Purpose:** fetch grounded context from Twin memory/index.
+- **Input:** query, entity scope, time filters, modality filters.
+- **Output:** retrieval_context snapshot with ranked items + provenance.
+- **Side effects:** writes retrieval_context event.
+- **Execution mode:** local-only or hybrid.
+- **Retrieval grounding required first?** This is the grounding capability.
+
+## 5) ask_twin
+- **Purpose:** produce grounded answer/recommendation from retrieved context.
+- **Input:** question + retrieval_context_id (or inline retrieval request).
+- **Output:** answer, recommendation candidates, confidence, citations.
+- **Side effects:** writes recommendation_event metadata.
+- **Execution mode:** hybrid (local or frontier reasoning).
+- **Retrieval grounding required first?** Yes (mandatory).
+
+## 6) get_entity_history
+- **Purpose:** return complete audit/history for a Twin entity.
+- **Input:** entity_type, entity_id, optional range/filter.
+- **Output:** ordered event stream + derived current state.
+- **Side effects:** none.
+- **Execution mode:** local-only or hybrid.
+- **Retrieval grounding required first?** No.
+
+## 7) generate_report
+- **Purpose:** compile operational report from Twin history.
+- **Input:** scope (farm/visit/date range), template, optional retrieval_context.
+- **Output:** report artifact + trace metadata.
+- **Side effects:** writes report_snapshot_event.
+- **Execution mode:** hybrid.
+- **Retrieval grounding required first?** Yes for narrative synthesis.
+
+## 8) propose_next_action
+- **Purpose:** suggest next operational step.
+- **Input:** current state snapshot + retrieval_context.
+- **Output:** ranked action options, rationale, confidence.
+- **Side effects:** writes recommendation_event.
+- **Execution mode:** hybrid.
+- **Retrieval grounding required first?** Yes (mandatory).

--- a/next-version/TWIN_STATE_MODEL.md
+++ b/next-version/TWIN_STATE_MODEL.md
@@ -1,0 +1,73 @@
+# TWIN_STATE_MODEL
+
+## Modeling principles
+- Event-sourced operational memory with append-first history.
+- Current state is derived from latest validated events.
+- Retrieval and recommendation traces are first-class events.
+
+## Entity definitions
+
+## 1) visit_event
+- **Purpose:** capture a field visit session and core metadata.
+- **Key fields:** visit_id, farm_id, actor_id, start_ts, end_ts, status, summary.
+- **Relationships:** has many observations, media assets, sync events.
+- **Lifecycle:** draft → reviewed → corrected → finalized.
+
+## 2) observation
+- **Purpose:** structured agronomic observations linked to visit.
+- **Key fields:** observation_id, visit_id, type, value, unit, confidence, source.
+- **Relationships:** belongs to visit_event; referenced by recommendations.
+- **Lifecycle:** captured → validated → superseded (optional).
+
+## 3) media_asset
+- **Purpose:** store photo/audio/video metadata and references.
+- **Key fields:** media_id, visit_id, local_uri, remote_uri, mime_type, captured_ts, hash.
+- **Relationships:** linked to observation and retrieval context.
+- **Lifecycle:** local_saved → queued_upload → uploaded → indexed.
+
+## 4) location_context
+- **Purpose:** preserve spatial context for capture and retrieval.
+- **Key fields:** location_id, visit_id, lat, lon, accuracy_m, geohash, timestamp.
+- **Relationships:** belongs to visit_event; enriches retrieval.
+- **Lifecycle:** captured → validated.
+
+## 5) sync_event
+- **Purpose:** track sync attempts and outcomes per object.
+- **Key fields:** sync_id, object_type, object_id, direction, attempt_no, result, error, ts.
+- **Relationships:** references visit/media/recommendation entities.
+- **Lifecycle:** queued → in_progress → succeeded | failed | dead_letter.
+
+## 6) retrieval_context
+- **Purpose:** immutable snapshot of context assembled for reasoning.
+- **Key fields:** retrieval_id, query, retrieved_items, scores, filters, ts, provenance.
+- **Relationships:** consumed by recommendation_event / ask_twin responses.
+- **Lifecycle:** generated → consumed → archived.
+
+## 7) recommendation_event
+- **Purpose:** store suggested action and rationale.
+- **Key fields:** rec_id, retrieval_id, model_mode, recommendation, rationale, confidence, ts.
+- **Relationships:** linked to observations and user decision events.
+- **Lifecycle:** proposed → accepted | modified | rejected.
+
+## 8) user_correction_event
+- **Purpose:** represent human edits/overrides with traceability.
+- **Key fields:** correction_id, target_entity, target_id, before, after, reason, actor_id, ts.
+- **Relationships:** references any mutable domain entity.
+- **Lifecycle:** submitted → applied.
+
+## 9) report_snapshot_event
+- **Purpose:** persist generated summaries/reports.
+- **Key fields:** report_id, scope, inputs, output_uri, generated_by, ts.
+- **Relationships:** references retrieval_context + recommendation_events.
+- **Lifecycle:** generated → shared | superseded.
+
+## 10) audit_history_event
+- **Purpose:** immutable audit stream for governance.
+- **Key fields:** audit_id, event_type, actor, payload_ref, ts.
+- **Relationships:** spans all entities.
+- **Lifecycle:** append-only.
+
+## State transition policy
+- No destructive overwrites of operational history.
+- Corrections and decisions append events; derived state updates views.
+- Retrieval and reasoning artifacts must reference exact input snapshots.

--- a/next-version/UI_BOUNDARY_CONTRACT.md
+++ b/next-version/UI_BOUNDARY_CONTRACT.md
@@ -1,0 +1,72 @@
+# UI_BOUNDARY_CONTRACT
+
+## Purpose
+Define exact interface between future React UI and existing Twin/Capability layer for Slice-1 parity.
+
+## Capability interface (UI -> adapter -> capabilities)
+
+## 1) `startVisit()`
+- **Input:** none
+- **Output:** `{ visitId, sliceState }`
+- **Errors:** contract/unexpected error string
+
+## 2) `captureObservation(observation)`
+- **Input:** non-empty observation string
+- **Output:** updated state (`capturedObservation`, `sliceState=draft`)
+- **Errors:** validation/state transition errors
+
+## 3) `reviewCorrect(correctedObservation)`
+- **Input:** non-empty correction string
+- **Output:** `sliceState=reviewed`
+- **Errors:** invalid transition/input
+
+## 4) `saveLocal()`
+- **Input:** none
+- **Output:** `localSaveStatus=saved`
+- **Errors:** invalid transition
+
+## 5) `sync(online:boolean)`
+- **Input:** online flag
+- **Output:** `syncStatus` in `{queued,succeeded}`
+- **Errors:** transition/contract errors
+
+## 6) `retrieve(question)`
+- **Input:** non-empty question
+- **Output:** `{ retrievalEventId, retrievalSummary }`
+- **Errors:** missing visit/invalid question
+
+## 7) `ask(question)`
+- **Input:** non-empty question + existing `retrievalEventId`
+- **Output:** `{ recommendation, groundedBy }`
+- **Errors:** retrieval missing (non-negotiable contract failure)
+
+## 8) `decide(decision)`
+- **Input:** `decision` in `{accepted,modified,rejected}`
+- **Output:** `sliceState=finalized`, decision status
+- **Errors:** invalid decision or transition
+
+## State surface contract (read-only to components)
+- `visitId`
+- `sliceState`
+- `capturedObservation`
+- `correctedObservation`
+- `localSaveStatus`
+- `syncStatus`
+- `retrievalSummary`
+- `retrievalEventId`
+- `recommendation`
+- `decision`
+- `lastError`
+
+## Error surface contract
+- UI shows user-readable `lastError` only.
+- Detailed debugging remains in logs/dev tooling, not end-user surface.
+
+## Sync status surface contract
+- Always render latest status explicitly (`not_synced`, `queued`, `succeeded`).
+- No hidden sync side effects in Slice-1 port.
+
+## Retrieval-before-reasoning enforcement
+- UI may disable Ask until retrieval context exists.
+- Service boundary still validates and rejects ungrounded ask attempts.
+- UI must present this failure clearly if attempted.

--- a/next-version/VERTICAL_SLICE_1.md
+++ b/next-version/VERTICAL_SLICE_1.md
@@ -1,0 +1,68 @@
+# VERTICAL_SLICE_1
+
+## Slice goal
+Deliver the **first shippable coherent loop** for vNext:
+Capture one field visit offline/online, sync it, retrieve grounded context, ask for recommendation, and write the decision back into Twin history.
+
+## Exact user journey
+1. Operator opens cockpit and starts "New Visit".
+2. Operator captures observations + photo(s) + location context.
+3. Operator reviews extracted fields and corrects errors.
+4. Operator taps "Save Local" (immediate local commit).
+5. If online: sync runs automatically; if offline: visit remains queued.
+6. Operator opens "Ask Twin" for this visit.
+7. System runs retrieval over Twin memory and shows context summary/provenance.
+8. System returns recommendation with confidence.
+9. Operator accepts/modifies/rejects recommendation.
+10. Decision is written as Twin event; optional report snapshot generated.
+
+## Exact Twin events involved
+1. `visit_event` (draft→reviewed→finalized)
+2. `observation` events (captured/validated)
+3. `media_asset` events (local_saved→queued_upload→uploaded/indexed)
+4. `location_context` event
+5. `sync_event` sequence (queued/in_progress/succeeded|failed)
+6. `retrieval_context` snapshot event
+7. `recommendation_event` (proposed)
+8. `user_correction_event` (if operator edits recommendation)
+9. `audit_history_event` entries for all transitions
+10. optional `report_snapshot_event`
+
+## Exact API capabilities involved
+- `ingest_visit`
+- `upload_media`
+- `sync_event`
+- `retrieve_context`
+- `ask_twin`
+- `propose_next_action`
+- optional `generate_report`
+- `get_entity_history` for audit screen
+
+## Exact local storage + sync behavior
+- Save Local always succeeds first or blocks with explicit error.
+- Sync engine is single-path, idempotent, and retries with backoff.
+- Failed sync is visible and actionable; no silent drops.
+- Local Twin remains source of truth until remote acknowledgment.
+
+## Exact retrieval/reasoning behavior
+- Retrieval is mandatory before reasoning.
+- Reasoning request must reference retrieval snapshot ID.
+- Recommendation payload must include:
+  - confidence
+  - rationale summary
+  - provenance pointer (retrieval snapshot)
+  - mode flag (local/hybrid/frontier-assisted)
+
+## Done criteria (slice acceptance)
+1. One operator can complete end-to-end journey without leaving canonical flow.
+2. Offline capture + delayed sync works without data loss.
+3. Sync failures are visible and recoverable.
+4. Ask/Recommendation is retrieval-grounded and auditable.
+5. Decision write-back creates linked Twin events.
+6. History view can reconstruct the full journey for the visit.
+
+## Explicit exclusions for slice 1
+- Multi-agent orchestration.
+- New wearable integrations.
+- Advanced automation policies.
+- Cross-farm analytics and multi-tenant scale features.

--- a/next-version/VNEXT_FOLDER_PLAN.md
+++ b/next-version/VNEXT_FOLDER_PLAN.md
@@ -1,0 +1,59 @@
+# VNEXT_FOLDER_PLAN
+
+## Objective
+Define the minimum folder/module structure for an isolated vNext implementation workspace while preserving baseline as reference.
+
+## Proposed minimal structure
+
+next-version/
+├── architecture/
+│   ├── NORTH_STAR_SUMMARY.md
+│   ├── NEXT_VERSION_ARCHITECTURE.md
+│   ├── CANONICAL_WORKFLOW.md
+│   ├── HUMAN_UI_STRATEGY.md
+│   ├── TWIN_STATE_MODEL.md
+│   ├── TWIN_API_CONTRACT.md
+│   ├── LOCAL_RAG_VS_FRONTIER_REASONING.md
+│   ├── BASELINE_TO_VNEXT_MAPPING.md
+│   ├── VERTICAL_SLICE_1.md
+│   └── IMPLEMENTATION_ROADMAP.md
+├── contracts/
+│   ├── twin-events.md
+│   ├── sync-contract.md
+│   ├── retrieval-contract.md
+│   └── capability-api.md
+├── decisions/
+│   ├── ADR-001-canonical-flow.md
+│   ├── ADR-002-single-sync-engine.md
+│   └── ADR-003-retrieval-before-reasoning.md
+├── validation/
+│   ├── slice-1-acceptance-checklist.md
+│   └── failure-scenarios.md
+└── notes/
+    └── baseline-observations.md
+
+## Module responsibilities
+- `architecture/`: canonical product/technical blueprint.
+- `contracts/`: implementable interface definitions used by UI and API layers.
+- `decisions/`: immutable rationale records to prevent architecture drift.
+- `validation/`: acceptance criteria and scenario matrices.
+- `notes/`: non-normative working observations.
+
+## Minimal implementation workspace plan (future)
+When coding begins, keep it thin:
+- `vnext_ui/` (cockpit experience only)
+- `vnext_twin_core/` (events + local state + sync engine)
+- `vnext_api/` (capability façade over backend primitives)
+
+Do not split further until slice 1 is stable.
+
+## What not to build yet in folder structure
+- No dedicated orchestration/agent framework module.
+- No separate model-provider abstraction package beyond what slice 1 needs.
+- No analytics/data-lake folder.
+- No plugin ecosystem folder.
+
+## Guardrails
+1. Every new folder must map to a canonical workflow step.
+2. Every contract file must map to at least one slice-1 acceptance criterion.
+3. No folder created for speculative future features.

--- a/next-version/contracts/capability-api.md
+++ b/next-version/contracts/capability-api.md
@@ -1,0 +1,22 @@
+# Capability API Contract (Slice 1)
+
+## Implemented capabilities
+- `ingest_visit`
+- `upload_media` (thin adapter)
+- `sync_event`
+- `retrieve_context`
+- `ask_twin`
+- `get_entity_history`
+- `generate_report` (stub)
+- `propose_next_action`
+
+## Shared-core rule
+All capabilities operate over the same `TwinService` instance and local-first state model.
+
+## Error semantics
+Contract violations raise `ContractError` in-process (HTTP mapping deferred).
+
+## Deferred
+- HTTP API surface
+- authn/authz
+- multi-tenant isolation

--- a/next-version/contracts/retrieval-contract.md
+++ b/next-version/contracts/retrieval-contract.md
@@ -1,0 +1,19 @@
+# Retrieval + Reasoning Boundary Contract (Slice 1)
+
+## Retrieval input
+- `visit_id`
+- non-empty `question`
+
+## Retrieval output
+- `retrieval_context` event with:
+  - `question`
+  - compact event context
+  - `grounded=true`
+  - `source=local_twin_memory`
+
+## Reasoning precondition
+Reasoning (`ask_twin` / `propose_next_action`) requires a valid prior `retrieval_context.event_id` for the same visit.
+
+## Failure behavior
+- Missing/invalid retrieval context -> contract error.
+- Empty reasoning question -> contract error.

--- a/next-version/contracts/sync-contract.md
+++ b/next-version/contracts/sync-contract.md
@@ -1,0 +1,21 @@
+# Sync Contract (Slice 1)
+
+## Scope
+Single-path sync semantics only.
+
+## Inputs
+- `visit_id`
+- `online: bool`
+
+## Outcomes
+- `online=true` -> `sync_event.status=succeeded`
+- `online=false` -> `sync_event.status=queued`
+
+## Idempotency
+Repeated sync call with same `(visit_id, status)` returns latest existing sync event instead of appending duplicates.
+
+## Deferred
+- retries/backoff
+- dead-letter queues
+- conflict resolution
+- remote transport protocol

--- a/next-version/contracts/twin-events.md
+++ b/next-version/contracts/twin-events.md
@@ -1,0 +1,29 @@
+# Twin Events Contract (Slice 1)
+
+## Required base fields
+Each event must include:
+- `event_id` (uuid)
+- `event_type`
+- `visit_id`
+- `payload` (object)
+- `ts` (UTC timestamp)
+
+## Allowed event types
+- `visit_event`
+- `observation`
+- `media_asset`
+- `location_context`
+- `sync_event`
+- `retrieval_context`
+- `recommendation_event`
+- `user_correction_event`
+- `audit_history_event`
+
+## Event-level validation
+- `visit_event.payload.status` in `{draft, reviewed, finalized}` when present.
+- `sync_event.payload.status` in `{queued, succeeded}`.
+- `retrieval_context` must include `question` and `grounded=true`.
+- `recommendation_event` must include `grounded_by`.
+
+## Idempotency expectation
+- Duplicate `event_id` is invalid and rejected by store.

--- a/next-version/decisions/ADR-001-canonical-flow.md
+++ b/next-version/decisions/ADR-001-canonical-flow.md
@@ -1,0 +1,2 @@
+# ADR-001 canonical flow
+Accepted: one canonical workflow for slice-1 only.

--- a/next-version/decisions/ADR-002-single-sync-engine.md
+++ b/next-version/decisions/ADR-002-single-sync-engine.md
@@ -1,0 +1,3 @@
+# ADR-002 single sync engine
+Accepted: one sync path in slice-1 (`SyncEngine`) with explicit outcomes (`queued`, `succeeded`) and simple idempotent same-status behavior.
+Deferred: conflict resolution and advanced retry policy.

--- a/next-version/decisions/ADR-003-retrieval-before-reasoning.md
+++ b/next-version/decisions/ADR-003-retrieval-before-reasoning.md
@@ -1,0 +1,3 @@
+# ADR-003 retrieval before reasoning
+Accepted: reasoning must reference an existing retrieval context for the same visit.
+If missing, raise contract error and do not emit recommendation events.

--- a/next-version/notes/baseline-observations.md
+++ b/next-version/notes/baseline-observations.md
@@ -1,0 +1,2 @@
+# baseline observations
+See existing architecture docs in `next-version/` for baseline mapping.

--- a/next-version/tests/test_baseline_adapter.py
+++ b/next-version/tests/test_baseline_adapter.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vnext_ui.baseline_adapter import BaselineCockpitAdapter
+
+
+class BaselineAdapterTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.adapter = BaselineCockpitAdapter(Path(self.tmp.name) / "adapter-events.json")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_slice_a_flow_and_status_surfaces(self):
+        self.assertTrue(self.adapter.act("start_visit", {})[1] is None)
+        self.adapter.act("capture", {"observation": "obs"})
+        self.adapter.act("review_correct", {"corrected_observation": "corr"})
+        self.adapter.act("save_local", {})
+        self.adapter.act("sync", {"online": False})
+        self.adapter.act("retrieve", {"question": "what now"})
+        self.adapter.act("ask", {"question": "recommend"})
+        self.adapter.act("decide", {"decision": "accepted"})
+        state = self.adapter.state
+        self.assertEqual(state["slice_state"], "finalized")
+        self.assertEqual(state["sync_status"], "queued")
+
+    def test_retrieval_before_reasoning_enforced(self):
+        self.adapter.act("start_visit", {})
+        self.adapter.act("capture", {"observation": "obs"})
+        self.adapter.act("review_correct", {"corrected_observation": "corr"})
+        self.adapter.act("save_local", {})
+        state, err = self.adapter.act("ask", {"question": "premature"})
+        self.assertIsNotNone(err)
+        self.assertIn("retrieval_context", err)
+        self.assertIn("retrieval_context", state.last_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/next-version/tests/test_gui_controller.py
+++ b/next-version/tests/test_gui_controller.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vnext_ui.controller import CockpitController
+
+
+class GuiControllerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.controller = CockpitController(Path(self.tmp.name) / "gui-events.json")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_canonical_flow_reaches_finalized(self) -> None:
+        self.controller.start_visit()
+        self.controller.capture("obs")
+        self.controller.review_correct("corr")
+        self.controller.save_local()
+        self.controller.sync(online=False)
+        self.controller.retrieve("what now")
+        self.controller.ask("recommend")
+        self.controller.decide("accepted")
+        self.assertEqual(self.controller.state.slice_state, "finalized")
+        self.assertEqual(self.controller.state.sync_status, "queued")
+
+    def test_retrieval_before_reasoning_enforced_in_gui_controller(self) -> None:
+        self.controller.start_visit()
+        self.controller.capture("obs")
+        self.controller.review_correct("corr")
+        self.controller.save_local()
+        state, err = self.controller.safe_call(self.controller.ask, "recommend now")
+        self.assertIsNotNone(err)
+        self.assertIn("retrieval_context", state.last_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/next-version/tests/test_react_api.py
+++ b/next-version/tests/test_react_api.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import unittest
+from http.client import HTTPConnection
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vnext_ui.react_api import ReactCockpitApi, make_handler
+from http.server import ThreadingHTTPServer
+
+
+class ReactApiTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        db = Path(__file__).resolve().parents[1] / "data" / "react-api-test-events.json"
+        api = ReactCockpitApi(db)
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(api))
+        cls.port = cls.server.server_port
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        time.sleep(0.05)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def post(self, action: str, **payload):
+        conn = HTTPConnection("127.0.0.1", self.port, timeout=3)
+        body = json.dumps({"action": action, **payload})
+        conn.request("POST", "/api/action", body=body, headers={"Content-Type": "application/json"})
+        res = conn.getresponse()
+        data = json.loads(res.read().decode("utf-8"))
+        conn.close()
+        return data
+
+    def test_static_baseline_shape_route_available(self):
+        conn = HTTPConnection("127.0.0.1", self.port, timeout=3)
+        conn.request("GET", "/baseline")
+        res = conn.getresponse()
+        body = res.read().decode("utf-8")
+        conn.close()
+        self.assertEqual(res.status, 200)
+        self.assertIn("Baseline-Shaped Slice A Cockpit", body)
+
+    def test_api_canonical_flow(self):
+        self.assertTrue(self.post("start_visit")["ok"])
+        self.assertTrue(self.post("capture", observation="obs")["ok"])
+        self.assertTrue(self.post("review_correct", corrected_observation="corr")["ok"])
+        self.assertTrue(self.post("save_local")["ok"])
+        sync = self.post("sync", online=False)
+        self.assertTrue(sync["ok"])
+        self.assertEqual(sync["state"]["sync_status"], "queued")
+        self.assertTrue(self.post("retrieve", question="what now")["ok"])
+        self.assertTrue(self.post("ask", question="recommend")["ok"])
+        decide = self.post("decide", decision="accepted")
+        self.assertTrue(decide["ok"])
+        self.assertEqual(decide["state"]["slice_state"], "finalized")
+
+    def test_retrieval_before_reasoning_enforced(self):
+        self.post("start_visit")
+        self.post("capture", observation="obs")
+        self.post("review_correct", corrected_observation="corr")
+        self.post("save_local")
+        ask = self.post("ask", question="no retrieval")
+        self.assertFalse(ask["ok"])
+        self.assertIn("retrieval_context", ask["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/next-version/tests/test_slice1.py
+++ b/next-version/tests/test_slice1.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vnext_api import TwinCapabilities
+from vnext_twin_core import TwinService
+from vnext_twin_core.models import ContractError, TwinEvent
+
+
+class Slice1Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "events.json"
+        self.service = TwinService(self.db)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_happy_path_end_to_end(self) -> None:
+        visit_id = self.service.start_visit()
+        self.service.capture(visit_id, "obs", "local://a.jpg", 1.0, 2.0)
+        self.service.review_and_correct(visit_id, "corrected")
+        self.service.save_local(visit_id)
+        sync_event = self.service.sync(visit_id, online=True)
+        retrieval = self.service.retrieve(visit_id, "what now")
+        rec = self.service.ask(visit_id, retrieval.event_id, "next action")
+        self.service.decide(visit_id, "accepted")
+
+        self.assertEqual(sync_event.payload["status"], "succeeded")
+        self.assertEqual(rec.event_type, "recommendation_event")
+        self.assertEqual(self.service.store.latest_visit_state(visit_id), "finalized")
+
+    def test_offline_sync_status(self) -> None:
+        visit_id = self.service.start_visit()
+        self.service.capture(visit_id, "obs", "local://a.jpg", 1.0, 2.0)
+        self.service.review_and_correct(visit_id, "corrected")
+        sync_event = self.service.sync(visit_id, online=False)
+        self.assertEqual(sync_event.payload["status"], "queued")
+
+    def test_reasoning_requires_retrieval(self) -> None:
+        visit_id = self.service.start_visit()
+        self.service.capture(visit_id, "obs", "local://a.jpg", 1.0, 2.0)
+        self.service.review_and_correct(visit_id, "corrected")
+        with self.assertRaises(ContractError):
+            self.service.ask(visit_id, "missing", "next")
+
+    def test_sync_idempotent_same_status(self) -> None:
+        visit_id = self.service.start_visit()
+        self.service.capture(visit_id, "obs", "local://a.jpg", 1.0, 2.0)
+        self.service.review_and_correct(visit_id, "corrected")
+        first = self.service.sync(visit_id, online=False)
+        second = self.service.sync(visit_id, online=False)
+        self.assertEqual(first.event_id, second.event_id)
+
+    def test_duplicate_event_rejected(self) -> None:
+        visit_id = self.service.start_visit()
+        event = TwinEvent.make("audit_history_event", visit_id, {"action": "x"})
+        self.service.store.append(event)
+        with self.assertRaises(ContractError):
+            self.service.store.append(event)
+
+    def test_api_facade_consistency(self) -> None:
+        caps = TwinCapabilities(self.db)
+        visit_id = caps.ingest_visit()
+        caps.upload_media(visit_id, "local://b.jpg")
+        retrieval = caps.retrieve_context(visit_id, "question")
+        rec = caps.ask_twin(visit_id, retrieval.event_id, "next")
+        self.assertEqual(rec.payload["grounded_by"], retrieval.event_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/next-version/validation/failure-scenarios.md
+++ b/next-version/validation/failure-scenarios.md
@@ -1,0 +1,17 @@
+# Failure scenarios (Slice 1)
+
+## Contract errors
+- malformed/invalid event payloads
+- invalid visit state transitions
+- empty retrieval/reasoning questions
+- reasoning without retrieval grounding
+- duplicate event id append
+
+## CLI handling
+- contract errors return exit code `2`
+- unexpected errors return exit code `1`
+
+## Explicitly deferred
+- remote network faults and partial write recovery
+- advanced queue retries/backoff
+- sync conflict reconciliation

--- a/next-version/validation/slice-1-acceptance-checklist.md
+++ b/next-version/validation/slice-1-acceptance-checklist.md
@@ -1,0 +1,8 @@
+# Slice-1 acceptance checklist
+
+- [x] end-to-end CLI journey succeeds online
+- [x] offline mode returns queued sync outcome
+- [x] reasoning without retrieval context fails
+- [x] repeated same-status sync call is idempotent
+- [x] duplicate event IDs are rejected by store
+- [x] API façade and CLI use the same Twin core behavior

--- a/next-version/vnext_api/__init__.py
+++ b/next-version/vnext_api/__init__.py
@@ -1,0 +1,3 @@
+from .capabilities import TwinCapabilities
+
+__all__ = ["TwinCapabilities"]

--- a/next-version/vnext_api/capabilities.py
+++ b/next-version/vnext_api/capabilities.py
@@ -1,0 +1,42 @@
+"""Agent-facing capability façade for Vertical Slice 1.
+
+This is an in-process adapter over TwinService (no network yet).
+Deferred: HTTP server, auth, multi-tenant controls.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from vnext_twin_core import TwinService
+
+
+class TwinCapabilities:
+    def __init__(self, db_path: Path):
+        self.twin = TwinService(db_path)
+
+    def ingest_visit(self) -> str:
+        return self.twin.start_visit()
+
+    def upload_media(self, visit_id: str, media_uri: str) -> None:
+        # Deferred: dedicated media pipeline. Slice-1 routes through capture flow.
+        self.twin.capture(visit_id, "media_uploaded", media_uri, 0.0, 0.0)
+
+    def sync_event(self, visit_id: str, online: bool):
+        return self.twin.sync(visit_id, online)
+
+    def retrieve_context(self, visit_id: str, query: str):
+        return self.twin.retrieve(visit_id, query)
+
+    def ask_twin(self, visit_id: str, retrieval_event_id: str, question: str):
+        return self.twin.ask(visit_id, retrieval_event_id, question)
+
+    def get_entity_history(self, visit_id: str):
+        return self.twin.store.list_events(visit_id)
+
+    def generate_report(self, visit_id: str) -> dict:
+        # Deferred: full report templating.
+        events = self.twin.store.list_events(visit_id)
+        return {"visit_id": visit_id, "event_count": len(events), "status": "stubbed_report"}
+
+    def propose_next_action(self, visit_id: str, retrieval_event_id: str, question: str):
+        return self.ask_twin(visit_id, retrieval_event_id, question)

--- a/next-version/vnext_twin_core/__init__.py
+++ b/next-version/vnext_twin_core/__init__.py
@@ -1,0 +1,3 @@
+from .service import TwinService
+
+__all__ = ["TwinService"]

--- a/next-version/vnext_twin_core/models.py
+++ b/next-version/vnext_twin_core/models.py
@@ -1,0 +1,84 @@
+"""Vertical Slice 1 Twin event model + contract validation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from typing import Any, Literal
+import uuid
+
+EventType = Literal[
+    "visit_event",
+    "observation",
+    "media_asset",
+    "location_context",
+    "sync_event",
+    "retrieval_context",
+    "recommendation_event",
+    "user_correction_event",
+    "audit_history_event",
+]
+
+VISIT_ALLOWED_STATES = {"draft", "reviewed", "finalized"}
+SYNC_ALLOWED_STATUSES = {"queued", "succeeded"}
+
+
+class ContractError(ValueError):
+    """Raised when incoming event/capability payload violates Slice-1 contracts."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class TwinEvent:
+    event_id: str
+    event_type: EventType
+    visit_id: str
+    payload: dict[str, Any]
+    ts: str
+
+    @staticmethod
+    def make(event_type: EventType, visit_id: str, payload: dict[str, Any]) -> "TwinEvent":
+        if not visit_id:
+            raise ContractError("visit_id is required")
+        if not isinstance(payload, dict):
+            raise ContractError("payload must be a dict")
+        event = TwinEvent(
+            event_id=str(uuid.uuid4()),
+            event_type=event_type,
+            visit_id=visit_id,
+            payload=payload,
+            ts=utc_now(),
+        )
+        event.validate()
+        return event
+
+    def validate(self) -> None:
+        if not self.event_id:
+            raise ContractError("event_id is required")
+        if self.event_type == "visit_event":
+            status = self.payload.get("status")
+            if status is not None and status not in VISIT_ALLOWED_STATES:
+                raise ContractError(f"invalid visit state: {status}")
+        if self.event_type == "sync_event":
+            status = self.payload.get("status")
+            if status not in SYNC_ALLOWED_STATUSES:
+                raise ContractError(f"invalid sync status: {status}")
+        if self.event_type == "retrieval_context":
+            if not self.payload.get("question"):
+                raise ContractError("retrieval_context requires question")
+            if self.payload.get("grounded") is not True:
+                raise ContractError("retrieval_context must be grounded=True")
+        if self.event_type == "recommendation_event":
+            if not self.payload.get("grounded_by"):
+                raise ContractError("recommendation_event requires grounded_by retrieval id")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "TwinEvent":
+        event = TwinEvent(**data)
+        event.validate()
+        return event

--- a/next-version/vnext_twin_core/reasoning.py
+++ b/next-version/vnext_twin_core/reasoning.py
@@ -1,0 +1,39 @@
+"""Reasoning boundary for Vertical Slice 1.
+
+Rule enforced: ask/recommend requires retrieval_context first.
+"""
+from __future__ import annotations
+
+from .models import TwinEvent, ContractError
+from .store import TwinStore
+
+
+class ReasoningService:
+    def __init__(self, store: TwinStore):
+        self.store = store
+
+    def ask_twin(self, visit_id: str, retrieval_event_id: str, question: str) -> TwinEvent:
+        if not question.strip():
+            raise ContractError("question is required")
+
+        retrieval_events = [
+            e
+            for e in self.store.list_events(visit_id)
+            if e["event_type"] == "retrieval_context" and e["event_id"] == retrieval_event_id
+        ]
+        if not retrieval_events:
+            raise ContractError("retrieval_context is required before reasoning")
+
+        rec = TwinEvent.make(
+            "recommendation_event",
+            visit_id,
+            {
+                "question": question,
+                "recommendation": "Inspect affected zone within 24h and capture follow-up evidence.",
+                "confidence": 0.62,
+                "mode": "local_stub_reasoning",
+                "grounded_by": retrieval_event_id,
+            },
+        )
+        self.store.append(rec)
+        return rec

--- a/next-version/vnext_twin_core/retrieval.py
+++ b/next-version/vnext_twin_core/retrieval.py
@@ -1,0 +1,37 @@
+"""Retrieval boundary for Vertical Slice 1 (local-only context)."""
+from __future__ import annotations
+
+from .models import TwinEvent, ContractError
+from .store import TwinStore
+
+
+class RetrievalService:
+    def __init__(self, store: TwinStore):
+        self.store = store
+
+    def retrieve_context(self, visit_id: str, question: str) -> TwinEvent:
+        if not question.strip():
+            raise ContractError("question is required")
+        events = self.store.list_events(visit_id)
+        if not events:
+            raise ContractError("cannot retrieve context for unknown visit")
+
+        compact = [
+            {
+                "event_type": e["event_type"],
+                "ts": e["ts"],
+            }
+            for e in events
+        ][-10:]
+        retrieval = TwinEvent.make(
+            "retrieval_context",
+            visit_id,
+            {
+                "question": question,
+                "items": compact,
+                "grounded": True,
+                "source": "local_twin_memory",
+            },
+        )
+        self.store.append(retrieval)
+        return retrieval

--- a/next-version/vnext_twin_core/service.py
+++ b/next-version/vnext_twin_core/service.py
@@ -1,0 +1,71 @@
+"""Vertical Slice 1 orchestration service for canonical workflow."""
+from __future__ import annotations
+
+from pathlib import Path
+import uuid
+
+from .models import TwinEvent, ContractError
+from .store import TwinStore
+from .sync import SyncEngine
+from .retrieval import RetrievalService
+from .reasoning import ReasoningService
+
+
+class TwinService:
+    def __init__(self, db_path: Path):
+        self.store = TwinStore(db_path)
+        self.sync_engine = SyncEngine(self.store)
+        self.retrieval = RetrievalService(self.store)
+        self.reasoning = ReasoningService(self.store)
+
+    def _require_state(self, visit_id: str, allowed: set[str]) -> None:
+        current = self.store.latest_visit_state(visit_id)
+        if current not in allowed:
+            raise ContractError(f"invalid transition from state={current}; allowed={sorted(allowed)}")
+
+    def start_visit(self) -> str:
+        visit_id = str(uuid.uuid4())
+        self.store.append(TwinEvent.make("visit_event", visit_id, {"status": "draft"}))
+        return visit_id
+
+    def capture(self, visit_id: str, observation: str, media_uri: str, lat: float, lon: float) -> None:
+        self._require_state(visit_id, {"draft"})
+        if not observation.strip():
+            raise ContractError("observation is required")
+        if not media_uri.strip():
+            raise ContractError("media_uri is required")
+        self.store.append(TwinEvent.make("observation", visit_id, {"text": observation}))
+        self.store.append(TwinEvent.make("media_asset", visit_id, {"local_uri": media_uri, "state": "local_saved"}))
+        self.store.append(TwinEvent.make("location_context", visit_id, {"lat": lat, "lon": lon}))
+
+    def review_and_correct(self, visit_id: str, corrected_observation: str) -> None:
+        self._require_state(visit_id, {"draft"})
+        if not corrected_observation.strip():
+            raise ContractError("corrected_observation is required")
+        self.store.append(TwinEvent.make("user_correction_event", visit_id, {"observation": corrected_observation}))
+        self.store.append(TwinEvent.make("visit_event", visit_id, {"status": "reviewed"}))
+
+    def save_local(self, visit_id: str) -> None:
+        self._require_state(visit_id, {"draft", "reviewed"})
+        self.store.append(TwinEvent.make("audit_history_event", visit_id, {"action": "save_local"}))
+
+    def sync(self, visit_id: str, online: bool) -> TwinEvent:
+        self._require_state(visit_id, {"reviewed", "draft"})
+        return self.sync_engine.sync_visit(visit_id, online)
+
+    def retrieve(self, visit_id: str, question: str) -> TwinEvent:
+        self._require_state(visit_id, {"reviewed", "draft"})
+        return self.retrieval.retrieve_context(visit_id, question)
+
+    def ask(self, visit_id: str, retrieval_event_id: str, question: str) -> TwinEvent:
+        self._require_state(visit_id, {"reviewed", "draft"})
+        return self.reasoning.ask_twin(visit_id, retrieval_event_id, question)
+
+    def decide(self, visit_id: str, decision: str) -> TwinEvent:
+        self._require_state(visit_id, {"reviewed", "draft"})
+        if decision not in {"accepted", "modified", "rejected"}:
+            raise ContractError("decision must be one of: accepted, modified, rejected")
+        event = TwinEvent.make("user_correction_event", visit_id, {"decision": decision})
+        self.store.append(event)
+        self.store.append(TwinEvent.make("visit_event", visit_id, {"status": "finalized"}))
+        return event

--- a/next-version/vnext_twin_core/store.py
+++ b/next-version/vnext_twin_core/store.py
@@ -1,0 +1,42 @@
+"""Local-first Twin memory store for Vertical Slice 1."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .models import TwinEvent, ContractError
+
+
+class TwinStore:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.db_path.exists():
+            self._write({"events": []})
+
+    def _read(self) -> dict[str, Any]:
+        return json.loads(self.db_path.read_text())
+
+    def _write(self, data: dict[str, Any]) -> None:
+        self.db_path.write_text(json.dumps(data, indent=2))
+
+    def append(self, event: TwinEvent) -> None:
+        event.validate()
+        data = self._read()
+        if any(e["event_id"] == event.event_id for e in data["events"]):
+            raise ContractError(f"duplicate event_id: {event.event_id}")
+        data["events"].append(event.to_dict())
+        self._write(data)
+
+    def list_events(self, visit_id: str | None = None) -> list[dict[str, Any]]:
+        events = self._read()["events"]
+        if visit_id is None:
+            return events
+        return [e for e in events if e["visit_id"] == visit_id]
+
+    def latest_visit_state(self, visit_id: str) -> str | None:
+        visit_events = [e for e in self.list_events(visit_id) if e["event_type"] == "visit_event"]
+        if not visit_events:
+            return None
+        return visit_events[-1]["payload"].get("status")

--- a/next-version/vnext_twin_core/sync.py
+++ b/next-version/vnext_twin_core/sync.py
@@ -1,0 +1,39 @@
+"""Single-path sync contract stub for Vertical Slice 1.
+
+Deferred:
+- real network transport
+- conflict resolution
+- retries/backoff strategy
+"""
+from __future__ import annotations
+
+from .models import TwinEvent
+from .store import TwinStore
+
+
+class SyncEngine:
+    def __init__(self, store: TwinStore):
+        self.store = store
+
+    def sync_visit(self, visit_id: str, online: bool) -> TwinEvent:
+        status = "succeeded" if online else "queued"
+
+        # Idempotent behavior for repeated same-status calls.
+        prior = [
+            e for e in self.store.list_events(visit_id)
+            if e["event_type"] == "sync_event" and e["payload"].get("status") == status
+        ]
+        if prior:
+            return TwinEvent.from_dict(prior[-1])
+
+        event = TwinEvent.make(
+            "sync_event",
+            visit_id,
+            {
+                "status": status,
+                "mode": "single_path",
+                "idempotency_key": f"{visit_id}:{status}",
+            },
+        )
+        self.store.append(event)
+        return event

--- a/next-version/vnext_ui/baseline_adapter.py
+++ b/next-version/vnext_ui/baseline_adapter.py
@@ -1,0 +1,41 @@
+"""Baseline-aligned adapter for Adoption Slice A.
+
+Purpose:
+- keep React UI thin
+- keep controller/service as source of behavior
+- expose stable state/action surface for canonical flow
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .controller import CockpitController
+
+
+class BaselineCockpitAdapter:
+    def __init__(self, db_path: Path):
+        self.controller = CockpitController(db_path)
+
+    @property
+    def state(self) -> dict:
+        return self.controller.state.__dict__
+
+    def act(self, action: str, payload: dict):
+        c = self.controller
+        if action == "start_visit":
+            return c.safe_call(c.start_visit)
+        if action == "capture":
+            return c.safe_call(c.capture, payload.get("observation", ""))
+        if action == "review_correct":
+            return c.safe_call(c.review_correct, payload.get("corrected_observation", ""))
+        if action == "save_local":
+            return c.safe_call(c.save_local)
+        if action == "sync":
+            return c.safe_call(c.sync, bool(payload.get("online", True)))
+        if action == "retrieve":
+            return c.safe_call(c.retrieve, payload.get("question", ""))
+        if action == "ask":
+            return c.safe_call(c.ask, payload.get("question", ""))
+        if action == "decide":
+            return c.safe_call(c.decide, payload.get("decision", "accepted"))
+        return c.state, f"unknown action: {action}"

--- a/next-version/vnext_ui/cli.py
+++ b/next-version/vnext_ui/cli.py
@@ -1,0 +1,52 @@
+"""Minimal human UI flow for Vertical Slice 1 (CLI cockpit)."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from vnext_api.capabilities import TwinCapabilities  # noqa: E402
+from vnext_twin_core.models import ContractError  # noqa: E402
+
+
+def run_slice(online: bool) -> int:
+    caps = TwinCapabilities(ROOT / "data" / "slice1-events.json")
+
+    try:
+        visit_id = caps.ingest_visit()
+        caps.twin.capture(visit_id, "Leaf discoloration observed on north block", "local://photo-001.jpg", 45.1, 9.2)
+        caps.twin.review_and_correct(visit_id, "Leaf discoloration likely fungal; corrected note")
+        caps.twin.save_local(visit_id)
+
+        sync_event = caps.sync_event(visit_id, online=online)
+        retrieval = caps.retrieve_context(visit_id, "What should I do next?")
+        recommendation = caps.ask_twin(visit_id, retrieval.event_id, "Recommend immediate next action")
+        decision = caps.twin.decide(visit_id, "accepted")
+
+        print("visit_id:", visit_id)
+        print("sync_status:", sync_event.payload["status"])
+        print("retrieval_event_id:", retrieval.event_id)
+        print("recommendation:", recommendation.payload["recommendation"])
+        print("decision_event_id:", decision.event_id)
+        print("history_events:", len(caps.get_entity_history(visit_id)))
+        return 0
+    except ContractError as err:
+        print(f"contract_error: {err}")
+        return 2
+    except Exception as err:  # noqa: BLE001 - explicit safe fallback for CLI boundary
+        print(f"unexpected_error: {err}")
+        return 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Vertical Slice 1 cockpit flow")
+    parser.add_argument("--offline", action="store_true", help="Simulate offline mode (sync queued)")
+    args = parser.parse_args()
+    raise SystemExit(run_slice(online=not args.offline))
+
+
+if __name__ == "__main__":
+    main()

--- a/next-version/vnext_ui/controller.py
+++ b/next-version/vnext_ui/controller.py
@@ -1,0 +1,95 @@
+"""Thin UI controller over Twin capabilities for Slice-1 GUI."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from vnext_api.capabilities import TwinCapabilities  # noqa: E402
+from vnext_twin_core.models import ContractError  # noqa: E402
+
+
+@dataclass
+class CockpitState:
+    visit_id: str = ""
+    slice_state: str = "idle"
+    captured_observation: str = ""
+    corrected_observation: str = ""
+    local_save_status: str = "not_saved"
+    sync_status: str = "not_synced"
+    retrieval_summary: str = ""
+    retrieval_event_id: str = ""
+    recommendation: str = ""
+    decision: str = ""
+    last_error: str = ""
+
+
+class CockpitController:
+    def __init__(self, db_path: Path):
+        self.caps = TwinCapabilities(db_path)
+        self.state = CockpitState()
+
+    def _update_state(self, **kwargs: str) -> CockpitState:
+        for key, value in kwargs.items():
+            setattr(self.state, key, value)
+        return self.state
+
+    def start_visit(self) -> CockpitState:
+        visit_id = self.caps.ingest_visit()
+        return self._update_state(
+            visit_id=visit_id,
+            slice_state="draft",
+            local_save_status="not_saved",
+            sync_status="not_synced",
+            retrieval_summary="",
+            retrieval_event_id="",
+            recommendation="",
+            decision="",
+            last_error="",
+        )
+
+    def capture(self, observation: str) -> CockpitState:
+        self.caps.twin.capture(self.state.visit_id, observation, "local://gui-photo.jpg", 0.0, 0.0)
+        return self._update_state(captured_observation=observation, slice_state="draft", last_error="")
+
+    def review_correct(self, corrected_observation: str) -> CockpitState:
+        self.caps.twin.review_and_correct(self.state.visit_id, corrected_observation)
+        return self._update_state(corrected_observation=corrected_observation, slice_state="reviewed", last_error="")
+
+    def save_local(self) -> CockpitState:
+        self.caps.twin.save_local(self.state.visit_id)
+        return self._update_state(local_save_status="saved", last_error="")
+
+    def sync(self, online: bool) -> CockpitState:
+        sync_event = self.caps.sync_event(self.state.visit_id, online=online)
+        return self._update_state(sync_status=sync_event.payload["status"], last_error="")
+
+    def retrieve(self, question: str) -> CockpitState:
+        retrieval = self.caps.retrieve_context(self.state.visit_id, question)
+        return self._update_state(
+            retrieval_event_id=retrieval.event_id,
+            retrieval_summary=f"{len(retrieval.payload['items'])} events grounded",
+            last_error="",
+        )
+
+    def ask(self, question: str) -> CockpitState:
+        rec = self.caps.ask_twin(self.state.visit_id, self.state.retrieval_event_id, question)
+        return self._update_state(recommendation=rec.payload["recommendation"], slice_state="reviewed", last_error="")
+
+    def decide(self, decision: str) -> CockpitState:
+        self.caps.twin.decide(self.state.visit_id, decision)
+        return self._update_state(decision=decision, slice_state="finalized", last_error="")
+
+    def safe_call(self, fn, *args):
+        try:
+            state = fn(*args)
+            return state, None
+        except ContractError as err:
+            self.state.last_error = str(err)
+            return self.state, str(err)
+        except Exception as err:  # noqa: BLE001
+            self.state.last_error = f"unexpected: {err}"
+            return self.state, self.state.last_error

--- a/next-version/vnext_ui/gui.py
+++ b/next-version/vnext_ui/gui.py
@@ -1,0 +1,150 @@
+"""Tkinter graphical cockpit for Vertical Slice 1."""
+from __future__ import annotations
+
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk
+
+from controller import CockpitController
+
+
+class CockpitApp:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.root.title("vNext Slice-1 Cockpit")
+        self.root.geometry("840x680")
+
+        self.controller = CockpitController(Path(__file__).resolve().parents[1] / "data" / "slice1-gui-events.json")
+
+        self.observation_var = tk.StringVar()
+        self.correction_var = tk.StringVar()
+        self.question_var = tk.StringVar()
+        self.ask_var = tk.StringVar()
+        self.online_var = tk.BooleanVar(value=True)
+        self.decision_var = tk.StringVar(value="accepted")
+
+        self.status_text = tk.StringVar(value="Ready")
+        self.error_text = tk.StringVar(value="")
+
+        self.visit_id_text = tk.StringVar(value="-")
+        self.slice_state_text = tk.StringVar(value="idle")
+        self.capture_summary_text = tk.StringVar(value="-")
+        self.local_save_text = tk.StringVar(value="not_saved")
+        self.sync_status_text = tk.StringVar(value="not_synced")
+        self.retrieval_summary_text = tk.StringVar(value="-")
+        self.recommendation_text = tk.StringVar(value="-")
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        frm = ttk.Frame(self.root, padding=12)
+        frm.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(frm, text="Vertical Slice 1 Graphical Cockpit", font=("Arial", 14, "bold")).pack(anchor=tk.W)
+        ttk.Label(frm, text="Canonical flow only: capture → review/correct → save → sync → retrieve → ask → decide").pack(anchor=tk.W, pady=(0, 10))
+
+        status = ttk.LabelFrame(frm, text="Status", padding=8)
+        status.pack(fill=tk.X, pady=4)
+        self._kv(status, "Visit ID", self.visit_id_text)
+        self._kv(status, "Slice State", self.slice_state_text)
+        self._kv(status, "Captured Observation", self.capture_summary_text)
+        self._kv(status, "Local Save", self.local_save_text)
+        self._kv(status, "Sync", self.sync_status_text)
+        self._kv(status, "Retrieval Summary", self.retrieval_summary_text)
+        self._kv(status, "Recommendation", self.recommendation_text)
+
+        actions = ttk.LabelFrame(frm, text="Actions", padding=8)
+        actions.pack(fill=tk.BOTH, expand=True, pady=4)
+
+        ttk.Button(actions, text="1) Start Visit", command=self.on_start).grid(row=0, column=0, sticky="w", pady=4)
+
+        ttk.Label(actions, text="2) Capture observation").grid(row=1, column=0, sticky="w")
+        ttk.Entry(actions, textvariable=self.observation_var, width=70).grid(row=1, column=1, sticky="ew", padx=6)
+        ttk.Button(actions, text="Capture", command=self.on_capture).grid(row=1, column=2, padx=4)
+
+        ttk.Label(actions, text="3) Review/Correct").grid(row=2, column=0, sticky="w")
+        ttk.Entry(actions, textvariable=self.correction_var, width=70).grid(row=2, column=1, sticky="ew", padx=6)
+        ttk.Button(actions, text="Review+Correct", command=self.on_review).grid(row=2, column=2, padx=4)
+
+        ttk.Button(actions, text="4) Save Local", command=self.on_save).grid(row=3, column=0, sticky="w", pady=4)
+
+        ttk.Checkbutton(actions, text="Online sync", variable=self.online_var).grid(row=4, column=0, sticky="w")
+        ttk.Button(actions, text="5) Sync", command=self.on_sync).grid(row=4, column=2, sticky="e", padx=4)
+
+        ttk.Label(actions, text="6) Retrieve question").grid(row=5, column=0, sticky="w")
+        ttk.Entry(actions, textvariable=self.question_var, width=70).grid(row=5, column=1, sticky="ew", padx=6)
+        ttk.Button(actions, text="Retrieve", command=self.on_retrieve).grid(row=5, column=2, padx=4)
+
+        ttk.Label(actions, text="7) Ask/Reason").grid(row=6, column=0, sticky="w")
+        ttk.Entry(actions, textvariable=self.ask_var, width=70).grid(row=6, column=1, sticky="ew", padx=6)
+        ttk.Button(actions, text="Ask", command=self.on_ask).grid(row=6, column=2, padx=4)
+
+        ttk.Label(actions, text="8) Decision").grid(row=7, column=0, sticky="w")
+        ttk.Combobox(actions, textvariable=self.decision_var, values=["accepted", "modified", "rejected"], width=12, state="readonly").grid(row=7, column=1, sticky="w", padx=6)
+        ttk.Button(actions, text="Decide", command=self.on_decide).grid(row=7, column=2, padx=4)
+
+        actions.columnconfigure(1, weight=1)
+
+        ttk.Label(frm, textvariable=self.status_text).pack(anchor=tk.W, pady=(8, 2))
+        ttk.Label(frm, textvariable=self.error_text, foreground="#b00020", wraplength=780).pack(anchor=tk.W)
+
+    def _kv(self, parent, k: str, var: tk.StringVar) -> None:
+        row = ttk.Frame(parent)
+        row.pack(fill=tk.X, pady=1)
+        ttk.Label(row, text=f"{k}:", width=22).pack(side=tk.LEFT)
+        ttk.Label(row, textvariable=var).pack(side=tk.LEFT)
+
+    def _sync_view(self, status: str) -> None:
+        st = self.controller.state
+        self.visit_id_text.set(st.visit_id or "-")
+        self.slice_state_text.set(st.slice_state)
+        self.capture_summary_text.set(st.captured_observation or "-")
+        self.local_save_text.set(st.local_save_status)
+        self.sync_status_text.set(st.sync_status)
+        self.retrieval_summary_text.set(st.retrieval_summary or "-")
+        self.recommendation_text.set(st.recommendation or "-")
+        self.status_text.set(status)
+        self.error_text.set(st.last_error)
+
+    def on_start(self):
+        _, err = self.controller.safe_call(self.controller.start_visit)
+        self._sync_view("Visit started" if not err else "Start failed")
+
+    def on_capture(self):
+        _, err = self.controller.safe_call(self.controller.capture, self.observation_var.get())
+        self._sync_view("Captured" if not err else "Capture failed")
+
+    def on_review(self):
+        _, err = self.controller.safe_call(self.controller.review_correct, self.correction_var.get())
+        self._sync_view("Reviewed/corrected" if not err else "Review failed")
+
+    def on_save(self):
+        _, err = self.controller.safe_call(self.controller.save_local)
+        self._sync_view("Saved locally" if not err else "Save failed")
+
+    def on_sync(self):
+        _, err = self.controller.safe_call(self.controller.sync, self.online_var.get())
+        self._sync_view("Sync updated" if not err else "Sync failed")
+
+    def on_retrieve(self):
+        _, err = self.controller.safe_call(self.controller.retrieve, self.question_var.get())
+        self._sync_view("Context retrieved" if not err else "Retrieve failed")
+
+    def on_ask(self):
+        _, err = self.controller.safe_call(self.controller.ask, self.ask_var.get())
+        self._sync_view("Recommendation ready" if not err else "Ask failed")
+
+    def on_decide(self):
+        _, err = self.controller.safe_call(self.controller.decide, self.decision_var.get())
+        self._sync_view("Decision recorded" if not err else "Decision failed")
+
+
+def main() -> None:
+    root = tk.Tk()
+    app = CockpitApp(root)
+    app._sync_view("Ready")
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/next-version/vnext_ui/react_api.py
+++ b/next-version/vnext_ui/react_api.py
@@ -1,0 +1,103 @@
+"""Local in-process API for thin React cockpit over Slice-1 controller.
+
+No external backend integration; this only exposes current local controller behavior.
+"""
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+from .baseline_adapter import BaselineCockpitAdapter
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC_DIR = Path(__file__).resolve().parent / "react_cockpit"
+BASELINE_SHAPE_DIR = STATIC_DIR / "baseline_shape"
+
+
+class ReactCockpitApi:
+    def __init__(self, db_path: Path):
+        self.adapter = BaselineCockpitAdapter(db_path)
+
+    def dispatch(self, action: str, payload: dict):
+        return self.adapter.act(action, payload)
+
+
+def make_handler(api: ReactCockpitApi):
+    class Handler(BaseHTTPRequestHandler):
+        def _send_json(self, code: int, obj: dict):
+            body = json.dumps(obj).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_file(self, path: Path, content_type: str):
+            if not path.exists():
+                self.send_error(404)
+                return
+            data = path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path in ["/", "/index.html"]:
+                self._send_file(STATIC_DIR / "index.html", "text/html; charset=utf-8")
+                return
+            if parsed.path in ["/baseline", "/baseline/"]:
+                self._send_file(BASELINE_SHAPE_DIR / "index.html", "text/html; charset=utf-8")
+                return
+            if parsed.path.startswith("/baseline/apps/web/src/"):
+                rel = parsed.path.replace("/baseline/", "")
+                self._send_file(BASELINE_SHAPE_DIR / rel, "application/javascript; charset=utf-8")
+                return
+            if parsed.path == "/app.js":
+                self._send_file(STATIC_DIR / "app.js", "application/javascript; charset=utf-8")
+                return
+            if parsed.path == "/api/state":
+                self._send_json(200, {"state": api.adapter.state})
+                return
+            self.send_error(404)
+
+        def do_POST(self):
+            parsed = urlparse(self.path)
+            if parsed.path != "/api/action":
+                self.send_error(404)
+                return
+
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length)
+            try:
+                payload = json.loads(raw.decode("utf-8") or "{}")
+            except json.JSONDecodeError:
+                self._send_json(400, {"error": "invalid json"})
+                return
+
+            action = payload.get("action")
+            state, err = api.dispatch(action, payload)
+            self._send_json(200, {"ok": err is None, "error": err, "state": state.__dict__})
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    return Handler
+
+
+def run_server(host: str = "127.0.0.1", port: int = 8765):
+    api = ReactCockpitApi(ROOT / "data" / "react-cockpit-events.json")
+    server = ThreadingHTTPServer((host, port), make_handler(api))
+    print(f"React cockpit server running at http://{host}:{port}")
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/next-version/vnext_ui/react_cockpit/app.js
+++ b/next-version/vnext_ui/react_cockpit/app.js
@@ -1,0 +1,73 @@
+const { useEffect, useState } = React;
+
+function StatusPanel({ state }) {
+  return (
+    <div className="panel">
+      <div className="kv"><span className="label">Visit ID</span>{state.visit_id || '-'}</div>
+      <div className="kv"><span className="label">Slice State</span>{state.slice_state}</div>
+      <div className="kv"><span className="label">Captured Observation</span>{state.captured_observation || '-'}</div>
+      <div className="kv"><span className="label">Local Save</span>{state.local_save_status}</div>
+      <div className="kv"><span className="label">Sync Status</span>{state.sync_status}</div>
+      <div className="kv"><span className="label">Retrieval Summary</span>{state.retrieval_summary || '-'}</div>
+      <div className="kv"><span className="label">Recommendation</span>{state.recommendation || '-'}</div>
+      <div className="kv"><span className="label">Decision</span>{state.decision || '-'}</div>
+    </div>
+  );
+}
+
+function App() {
+  const [state, setState] = useState({
+    visit_id: "", slice_state: "idle", captured_observation: "", corrected_observation: "",
+    local_save_status: "not_saved", sync_status: "not_synced", retrieval_summary: "",
+    retrieval_event_id: "", recommendation: "", decision: "", last_error: "",
+  });
+  const [observation, setObservation] = useState("");
+  const [correctedObservation, setCorrectedObservation] = useState("");
+  const [retrieveQ, setRetrieveQ] = useState("");
+  const [askQ, setAskQ] = useState("");
+  const [online, setOnline] = useState(true);
+  const [decision, setDecision] = useState("accepted");
+  const [status, setStatus] = useState("Ready");
+
+  async function action(name, payload = {}, okText = "Done", failText = "Failed") {
+    const res = await fetch('/api/action', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: name, ...payload }),
+    });
+    const data = await res.json();
+    setState(data.state);
+    setStatus(data.ok ? okText : failText);
+  }
+
+  useEffect(() => { fetch('/api/state').then(r => r.json()).then(data => setState(data.state)); }, []);
+
+  return (
+    <div>
+      <h1>Slice-A React Cockpit</h1>
+      <div className="muted">start visit → capture → review/correct → save local → sync → retrieve → ask/reason → decide → result summary</div>
+      <StatusPanel state={state} />
+
+      <div className="panel">
+        <div className="row"><button onClick={() => action('start_visit', {}, 'Visit started', 'Start failed')}>1) Start Visit</button></div>
+        <div className="row"><input value={observation} onChange={e => setObservation(e.target.value)} placeholder="2) Observation" /><button onClick={() => action('capture', { observation }, 'Captured', 'Capture failed')}>Capture</button></div>
+        <div className="row"><input value={correctedObservation} onChange={e => setCorrectedObservation(e.target.value)} placeholder="3) Corrected observation" /><button onClick={() => action('review_correct', { corrected_observation: correctedObservation }, 'Reviewed', 'Review failed')}>Review+Correct</button></div>
+        <div className="row"><button onClick={() => action('save_local', {}, 'Saved locally', 'Save failed')}>4) Save Local</button></div>
+        <div className="row"><label><input type="checkbox" checked={online} onChange={e => setOnline(e.target.checked)} /> Online sync</label><button onClick={() => action('sync', { online }, 'Sync updated', 'Sync failed')}>5) Sync</button></div>
+        <div className="row"><input value={retrieveQ} onChange={e => setRetrieveQ(e.target.value)} placeholder="6) Retrieval question" /><button onClick={() => action('retrieve', { question: retrieveQ }, 'Context retrieved', 'Retrieve failed')}>Retrieve</button></div>
+        <div className="row"><input value={askQ} onChange={e => setAskQ(e.target.value)} placeholder="7) Ask question" /><button onClick={() => action('ask', { question: askQ }, 'Recommendation ready', 'Ask failed')}>Ask</button></div>
+        <div className="row"><select value={decision} onChange={e => setDecision(e.target.value)}><option value="accepted">accepted</option><option value="modified">modified</option><option value="rejected">rejected</option></select><button onClick={() => action('decide', { decision }, 'Decision recorded', 'Decision failed')}>8) Decide</button></div>
+      </div>
+
+      <div className="panel">
+        <strong>Result Summary</strong>
+        <div className="kv"><span className="label">Visit ID</span>{state.visit_id || '-'}</div>
+        <div className="kv"><span className="label">Final State</span>{state.slice_state}</div>
+        <div className="kv"><span className="label">Sync</span>{state.sync_status}</div>
+      </div>
+
+      <div><strong>Status:</strong> {status}</div>
+      <div className="error">{state.last_error || ''}</div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/AppShell.js
+++ b/next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/AppShell.js
@@ -1,0 +1,8 @@
+// Baseline-shaped app shell mounting single canonical cockpit view.
+window.AppShell = function AppShell() {
+  return React.createElement('div', null,
+    React.createElement('h1', null, 'Baseline-Shaped Slice A Cockpit'),
+    React.createElement('div', { className: 'muted' }, 'Canonical flow only; thin UI over adapter/controller boundary.'),
+    React.createElement(window.CockpitSliceA, null)
+  );
+};

--- a/next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/lib/cockpitAdapter.js
+++ b/next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/lib/cockpitAdapter.js
@@ -1,0 +1,16 @@
+// Thin baseline-aligned adapter for Slice A (UI boundary only).
+window.CockpitAdapter = {
+  async getState() {
+    const res = await fetch('/api/state');
+    const data = await res.json();
+    return data.state;
+  },
+  async action(action, payload = {}) {
+    const res = await fetch('/api/action', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, ...payload }),
+    });
+    return res.json();
+  },
+};

--- a/next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/views/CockpitSliceA.js
+++ b/next-version/vnext_ui/react_cockpit/baseline_shape/apps/web/src/views/CockpitSliceA.js
@@ -1,0 +1,54 @@
+// Baseline-shaped cockpit view container for Adoption Slice A only.
+window.CockpitSliceA = function CockpitSliceA() {
+  const [state, setState] = React.useState({
+    visit_id: '', slice_state: 'idle', captured_observation: '', corrected_observation: '',
+    local_save_status: 'not_saved', sync_status: 'not_synced', retrieval_summary: '',
+    retrieval_event_id: '', recommendation: '', decision: '', last_error: '',
+  });
+  const [status, setStatus] = React.useState('Ready');
+  const [observation, setObservation] = React.useState('');
+  const [corr, setCorr] = React.useState('');
+  const [q1, setQ1] = React.useState('');
+  const [q2, setQ2] = React.useState('');
+  const [online, setOnline] = React.useState(true);
+  const [decision, setDecision] = React.useState('accepted');
+
+  React.useEffect(() => {
+    window.CockpitAdapter.getState().then(setState);
+  }, []);
+
+  async function run(action, payload, okText, failText) {
+    const data = await window.CockpitAdapter.action(action, payload);
+    setState(data.state);
+    setStatus(data.ok ? okText : failText);
+  }
+
+  return React.createElement('div', null,
+    React.createElement('div', { className: 'panel' },
+      React.createElement('div', { className: 'kv' }, React.createElement('span', { className: 'label' }, 'Visit ID'), state.visit_id || '-'),
+      React.createElement('div', { className: 'kv' }, React.createElement('span', { className: 'label' }, 'State'), state.slice_state),
+      React.createElement('div', { className: 'kv' }, React.createElement('span', { className: 'label' }, 'Sync'), state.sync_status),
+      React.createElement('div', { className: 'kv' }, React.createElement('span', { className: 'label' }, 'Retrieval'), state.retrieval_summary || '-'),
+      React.createElement('div', { className: 'kv' }, React.createElement('span', { className: 'label' }, 'Recommendation'), state.recommendation || '-')
+    ),
+    React.createElement('div', { className: 'panel' },
+      React.createElement('div', { className: 'row' }, React.createElement('button', { onClick: () => run('start_visit', {}, 'Visit started', 'Start failed') }, '1) Start Visit')),
+      React.createElement('div', { className: 'row' }, React.createElement('input', { value: observation, onChange: e => setObservation(e.target.value), placeholder: '2) Observation' }), React.createElement('button', { onClick: () => run('capture', { observation }, 'Captured', 'Capture failed') }, 'Capture')),
+      React.createElement('div', { className: 'row' }, React.createElement('input', { value: corr, onChange: e => setCorr(e.target.value), placeholder: '3) Corrected observation' }), React.createElement('button', { onClick: () => run('review_correct', { corrected_observation: corr }, 'Reviewed', 'Review failed') }, 'Review+Correct')),
+      React.createElement('div', { className: 'row' }, React.createElement('button', { onClick: () => run('save_local', {}, 'Saved locally', 'Save failed') }, '4) Save Local')),
+      React.createElement('div', { className: 'row' }, React.createElement('label', null, React.createElement('input', { type: 'checkbox', checked: online, onChange: e => setOnline(e.target.checked) }), ' Online sync'), React.createElement('button', { onClick: () => run('sync', { online }, 'Sync updated', 'Sync failed') }, '5) Sync')),
+      React.createElement('div', { className: 'row' }, React.createElement('input', { value: q1, onChange: e => setQ1(e.target.value), placeholder: '6) Retrieve question' }), React.createElement('button', { onClick: () => run('retrieve', { question: q1 }, 'Context retrieved', 'Retrieve failed') }, 'Retrieve')),
+      React.createElement('div', { className: 'row' }, React.createElement('input', { value: q2, onChange: e => setQ2(e.target.value), placeholder: '7) Ask question' }), React.createElement('button', { onClick: () => run('ask', { question: q2 }, 'Recommendation ready', 'Ask failed') }, 'Ask')),
+      React.createElement('div', { className: 'row' },
+        React.createElement('select', { value: decision, onChange: e => setDecision(e.target.value) },
+          React.createElement('option', { value: 'accepted' }, 'accepted'),
+          React.createElement('option', { value: 'modified' }, 'modified'),
+          React.createElement('option', { value: 'rejected' }, 'rejected')
+        ),
+        React.createElement('button', { onClick: () => run('decide', { decision }, 'Decision recorded', 'Decision failed') }, '8) Decide')
+      )
+    ),
+    React.createElement('div', null, React.createElement('strong', null, 'Status: '), status),
+    React.createElement('div', { className: 'error' }, state.last_error || '')
+  );
+};

--- a/next-version/vnext_ui/react_cockpit/baseline_shape/index.html
+++ b/next-version/vnext_ui/react_cockpit/baseline_shape/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Baseline-Shaped Slice A Cockpit</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 16px; }
+      .muted { color: #555; margin-bottom: 8px; }
+      .panel { border: 1px solid #ddd; border-radius: 6px; padding: 10px; margin-bottom: 10px; }
+      .row { display: flex; gap: 8px; margin: 6px 0; align-items: center; }
+      input, select { flex: 1; padding: 6px; }
+      button { padding: 6px 10px; }
+      .error { color: #b00020; }
+      .label { display: inline-block; width: 130px; }
+      .kv { margin: 2px 0; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="/baseline/apps/web/src/lib/cockpitAdapter.js"></script>
+    <script src="/baseline/apps/web/src/views/CockpitSliceA.js"></script>
+    <script src="/baseline/apps/web/src/AppShell.js"></script>
+    <script>
+      ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(window.AppShell));
+    </script>
+  </body>
+</html>

--- a/next-version/vnext_ui/react_cockpit/index.html
+++ b/next-version/vnext_ui/react_cockpit/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>vNext Slice-1 React Cockpit</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 16px; }
+      h1 { margin: 0 0 8px; }
+      .muted { color: #555; margin-bottom: 12px; }
+      .panel { border: 1px solid #ddd; border-radius: 6px; padding: 10px; margin-bottom: 10px; }
+      .row { display: flex; gap: 8px; align-items: center; margin: 6px 0; }
+      input, select { flex: 1; padding: 6px; }
+      button { padding: 6px 10px; }
+      .error { color: #b00020; }
+      .kv { margin: 2px 0; }
+      .label { display: inline-block; width: 170px; color: #444; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" src="/app.js"></script>
+  </body>
+</html>

--- a/notes/multimodal-agentic-farm-visit-review.md
+++ b/notes/multimodal-agentic-farm-visit-review.md
@@ -1,0 +1,35 @@
+# Quick Review: Multimodal-Agentic-Farm-Visit
+
+Date reviewed: 2026-03-23
+Project URL: https://github.com/aciuffolini/Multimodal-Agentic-Farm-Visit
+
+## What the project appears to be
+- A hybrid field-assistant platform for agriculture, with:
+  - Mobile/offline data collection (photos, GPS, notes).
+  - Web/server analysis mode using multimodal RAG.
+- The stack described in the README combines:
+  - Frontend: React + Vite + Tailwind + Capacitor (web + Android APK).
+  - Backend: FastAPI service with CLIP embeddings and ChromaDB.
+  - Persistence: SQLite + filesystem.
+
+## Strong points
+- Clear product framing (field mode vs analysis mode).
+- Practical architecture split for mobile collection and server-side retrieval.
+- Explicit mention of offline path (local Llama model) for weak-connectivity contexts.
+- Repository includes setup/status docs beyond README, which can help onboarding.
+
+## Risks / gaps to validate before production use
+- Device constraints for offline LLM (~2GB model download, WebGPU compatibility, thermal impact).
+- Data governance for farm photos + geolocation (retention, consent, access controls).
+- Security hardening for API keys and private deployment assumptions.
+- Unknown test coverage and CI quality from README alone.
+
+## Suggested first due-diligence checks
+1. Verify end-to-end local run path (`apps/web/start-all-servers.ps1`) and confirm expected ports/services.
+2. Review `server/rag_service` model loading and embedding pipeline for resource usage and fallback behavior.
+3. Inspect data schema and migration flow for event/photo metadata lifecycle.
+4. Validate Android permission prompts and offline sync conflict resolution.
+5. Add/verify benchmark scenarios (latency, retrieval quality, offline battery impact).
+
+## Recommendation
+Promising prototype direction for real-world farm workflows, especially with multimodal retrieval plus offline operation. Before broader adoption, prioritize operational hardening: observability, test automation, security controls, and reproducible deployment docs.


### PR DESCRIPTION
### Motivation
- Promote a guarded, isolated `next-version/` vNext product line centered on an Agentic Twin core and a single canonical workflow (`start → capture → review/correct → save local → sync → retrieve → ask/reason → decide`).
- Provide clear contracts and adoption guidance so baseline code can be incrementally adapted without leaking business logic into UI layers.

### Description
- Replace the repository top-level README with a vNext product positioning and add a new `next-version/` workspace containing architecture, decisions, contracts, and migration/adoption docs. 
- Implement a Vertical Slice-1 local Twin stack under `next-version/`: `vnext_twin_core` (models, store, sync, retrieval, reasoning, service), `vnext_api` capability façade, and `vnext_ui` thin UI/controller/adapter pieces including `cli`, `gui`, `react_api`, and a baseline-shaped React cockpit static surface. 
- Add a baseline adapter `vnext_ui/baseline_adapter.py` and a `CockpitController` to keep UI thin and enforce invariants (notably retrieval-before-reasoning). 
- Add a broad set of tests under `next-version/tests` exercising the Twin service and UI-adapter surfaces (`test_slice1.py`, `test_react_api.py`, `test_gui_controller.py`, `test_baseline_adapter.py`) and many supporting docs and checklists for staged merges.

### Testing
- Ran the Slice-1 unit test suite with `python -m unittest discover -s next-version/tests -p 'test_*.py'`, and the test collection passed as reported in the pre-commit milestone check. 
- Tests include `test_slice1.py` (TwinService and store behavior), `test_react_api.py` (in-process HTTP API and baseline-shaped route), `test_gui_controller.py` (controller safe-call flows), and `test_baseline_adapter.py` (adapter action/state surfaces), and they all passed in the isolated workspace run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c183c0fda483299dcb6c48d0b0bf7d)